### PR TITLE
Enable tests/data/html5lib-tests/tokenizer/test3.test and other changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build: ## Build	the project
 	section "Cargo build" ;\
 	cargo build
 
+fix:
+	cargo clippy --fix --allow-dirty --allow-staged
+
 test_unit:
 	source test-utils.sh ;\
 	section "Cargo test" ;\

--- a/benches/tokenizer.rs
+++ b/benches/tokenizer.rs
@@ -1,22 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use gosub_engine::testing::tokenizer::{self, Test};
-
-fn tokenize(test: &Test) {
-    for mut builder in test.builders() {
-        let mut tokenizer = builder.build();
-
-        // If there is no output, still do an (initial) next token so the parser can generate
-        // errors.
-        if test.output.is_empty() {
-            tokenizer.next_token();
-        }
-
-        // There can be multiple tokens to match. Make sure we match all of them
-        for _ in test.output.iter() {
-            tokenizer.next_token();
-        }
-    }
-}
+use criterion::{criterion_group, criterion_main, Criterion};
+use gosub_engine::testing::tokenizer;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Criterion can report inconsistent results from run to run in some cases.  We attempt to
@@ -32,7 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             for root in &fixtures {
                 for test in &root.tests {
-                    tokenize(black_box(test))
+                    test.tokenize();
                 }
             }
         })

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -108,7 +108,7 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
                 current_test.data = current_test.data.trim_end().to_string();
                 tests.push(current_test);
                 current_test = Test {
-                    file_path: file_path.to_str().unwrap().clone().to_string(),
+                    file_path: file_path.to_str().unwrap().to_string(),
                     line: line_num,
                     data: "".to_string(),
                     errors: vec![],

--- a/src/html5_parser/error_logger.rs
+++ b/src/html5_parser/error_logger.rs
@@ -153,7 +153,7 @@ impl ParserError {
 }
 
 // Parser error that defines an error (message) on the given position
-#[derive(PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ParseError {
     pub message: String, // Parse message
     pub line: usize,     // Line number of the error

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -740,7 +740,7 @@ mod tests {
         let attr = HashMap::new();
 
         let mut node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
-        assert_eq!(node.has_attributes(), false);
+        assert!(!node.has_attributes());
 
         assert!(node.insert_attribute("key", "value").is_ok());
         assert!(node.has_attributes());

--- a/src/html5_parser/parser/mod.rs
+++ b/src/html5_parser/parser/mod.rs
@@ -3458,10 +3458,10 @@ mod test {
         node_create!(parser, "div");
         node_create!(parser, "p");
         node_create!(parser, "button");
-        assert_eq!(parser.is_in_scope("p", Scope::Regular), true);
-        assert_eq!(parser.is_in_scope("p", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("p", Scope::ListItem), true);
-        assert_eq!(parser.is_in_scope("p", Scope::Select), false);
+        assert!(parser.is_in_scope("p", Scope::Regular));
+        assert!(!parser.is_in_scope("p", Scope::Button));
+        assert!(parser.is_in_scope("p", Scope::ListItem));
+        assert!(!parser.is_in_scope("p", Scope::Select));
     }
 
     #[test]
@@ -3470,10 +3470,10 @@ mod test {
         let mut parser = Html5Parser::new(&mut stream);
 
         parser.open_elements.clear();
-        assert_eq!(parser.is_in_scope("p", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("p", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("p", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("p", Scope::Select), false);
+        assert!(!parser.is_in_scope("p", Scope::Regular));
+        assert!(!parser.is_in_scope("p", Scope::Button));
+        assert!(!parser.is_in_scope("p", Scope::ListItem));
+        assert!(!parser.is_in_scope("p", Scope::Select));
     }
 
     #[test]
@@ -3486,10 +3486,10 @@ mod test {
         node_create!(parser, "p");
         node_create!(parser, "button");
 
-        assert_eq!(parser.is_in_scope("foo", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("foo", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("foo", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("foo", Scope::Select), false);
+        assert!(!parser.is_in_scope("foo", Scope::Regular));
+        assert!(!parser.is_in_scope("foo", Scope::Button));
+        assert!(!parser.is_in_scope("foo", Scope::ListItem));
+        assert!(!parser.is_in_scope("foo", Scope::Select));
     }
 
     #[test]
@@ -3505,29 +3505,29 @@ mod test {
         node_create!(parser, "p");
         node_create!(parser, "span");
 
-        assert_eq!(parser.is_in_scope("p", Scope::Regular), true);
-        assert_eq!(parser.is_in_scope("p", Scope::ListItem), true);
-        assert_eq!(parser.is_in_scope("p", Scope::Button), true);
-        assert_eq!(parser.is_in_scope("p", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("p", Scope::Select), false);
+        assert!(parser.is_in_scope("p", Scope::Regular));
+        assert!(parser.is_in_scope("p", Scope::ListItem));
+        assert!(parser.is_in_scope("p", Scope::Button));
+        assert!(parser.is_in_scope("p", Scope::Table));
+        assert!(!parser.is_in_scope("p", Scope::Select));
 
-        assert_eq!(parser.is_in_scope("div", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("div", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("div", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("div", Scope::Table), false);
-        assert_eq!(parser.is_in_scope("div", Scope::Select), false);
+        assert!(!parser.is_in_scope("div", Scope::Regular));
+        assert!(!parser.is_in_scope("div", Scope::ListItem));
+        assert!(!parser.is_in_scope("div", Scope::Button));
+        assert!(!parser.is_in_scope("div", Scope::Table));
+        assert!(!parser.is_in_scope("div", Scope::Select));
 
-        assert_eq!(parser.is_in_scope("tr", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("tr", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("tr", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("tr", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("tr", Scope::Select), false);
+        assert!(!parser.is_in_scope("tr", Scope::Regular));
+        assert!(!parser.is_in_scope("tr", Scope::ListItem));
+        assert!(!parser.is_in_scope("tr", Scope::Button));
+        assert!(parser.is_in_scope("tr", Scope::Table));
+        assert!(!parser.is_in_scope("tr", Scope::Select));
 
-        assert_eq!(parser.is_in_scope("xmp", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("xmp", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("xmp", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("xmp", Scope::Table), false);
-        assert_eq!(parser.is_in_scope("xmp", Scope::Select), false);
+        assert!(!parser.is_in_scope("xmp", Scope::Regular));
+        assert!(!parser.is_in_scope("xmp", Scope::ListItem));
+        assert!(!parser.is_in_scope("xmp", Scope::Button));
+        assert!(!parser.is_in_scope("xmp", Scope::Table));
+        assert!(!parser.is_in_scope("xmp", Scope::Select));
     }
 
     #[test]
@@ -3542,11 +3542,11 @@ mod test {
         node_create!(parser, "div");
         node_create!(parser, "button");
 
-        assert_eq!(parser.is_in_scope("li", Scope::Regular), true);
-        assert_eq!(parser.is_in_scope("li", Scope::ListItem), true);
-        assert_eq!(parser.is_in_scope("li", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("li", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("li", Scope::Select), false);
+        assert!(parser.is_in_scope("li", Scope::Regular));
+        assert!(parser.is_in_scope("li", Scope::ListItem));
+        assert!(!parser.is_in_scope("li", Scope::Button));
+        assert!(parser.is_in_scope("li", Scope::Table));
+        assert!(!parser.is_in_scope("li", Scope::Select));
     }
 
     #[test]
@@ -3561,11 +3561,11 @@ mod test {
         node_create!(parser, "li");
         node_create!(parser, "p");
 
-        assert_eq!(parser.is_in_scope("li", Scope::Regular), true);
-        assert_eq!(parser.is_in_scope("li", Scope::ListItem), true);
-        assert_eq!(parser.is_in_scope("li", Scope::Button), true);
-        assert_eq!(parser.is_in_scope("li", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("li", Scope::Select), false);
+        assert!(parser.is_in_scope("li", Scope::Regular));
+        assert!(parser.is_in_scope("li", Scope::ListItem));
+        assert!(parser.is_in_scope("li", Scope::Button));
+        assert!(parser.is_in_scope("li", Scope::Table));
+        assert!(!parser.is_in_scope("li", Scope::Select));
     }
 
     #[test]
@@ -3582,11 +3582,11 @@ mod test {
         node_create!(parser, "button");
         node_create!(parser, "span");
 
-        assert_eq!(parser.is_in_scope("td", Scope::Regular), true);
-        assert_eq!(parser.is_in_scope("td", Scope::ListItem), true);
-        assert_eq!(parser.is_in_scope("td", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("td", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("td", Scope::Select), false);
+        assert!(parser.is_in_scope("td", Scope::Regular));
+        assert!(parser.is_in_scope("td", Scope::ListItem));
+        assert!(!parser.is_in_scope("td", Scope::Button));
+        assert!(parser.is_in_scope("td", Scope::Table));
+        assert!(!parser.is_in_scope("td", Scope::Select));
     }
 
     #[test]
@@ -3602,11 +3602,11 @@ mod test {
         node_create!(parser, "a");
         node_create!(parser, "span");
 
-        assert_eq!(parser.is_in_scope("div", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("div", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("div", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("div", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("div", Scope::Select), false);
+        assert!(!parser.is_in_scope("div", Scope::Regular));
+        assert!(!parser.is_in_scope("div", Scope::ListItem));
+        assert!(!parser.is_in_scope("div", Scope::Button));
+        assert!(parser.is_in_scope("div", Scope::Table));
+        assert!(!parser.is_in_scope("div", Scope::Select));
     }
 
     #[test]
@@ -3622,11 +3622,11 @@ mod test {
         node_create!(parser, "marquee");
         node_create!(parser, "p");
 
-        assert_eq!(parser.is_in_scope("ul", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("ul", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("ul", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("ul", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("ul", Scope::Select), false);
+        assert!(!parser.is_in_scope("ul", Scope::Regular));
+        assert!(!parser.is_in_scope("ul", Scope::ListItem));
+        assert!(!parser.is_in_scope("ul", Scope::Button));
+        assert!(parser.is_in_scope("ul", Scope::Table));
+        assert!(!parser.is_in_scope("ul", Scope::Select));
     }
 
     #[test]
@@ -3641,11 +3641,11 @@ mod test {
         node_create!(parser, "caption");
         node_create!(parser, "p");
 
-        assert_eq!(parser.is_in_scope("table", Scope::Regular), false);
-        assert_eq!(parser.is_in_scope("table", Scope::ListItem), false);
-        assert_eq!(parser.is_in_scope("table", Scope::Button), false);
-        assert_eq!(parser.is_in_scope("table", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("table", Scope::Select), false);
+        assert!(!parser.is_in_scope("table", Scope::Regular));
+        assert!(!parser.is_in_scope("table", Scope::ListItem));
+        assert!(!parser.is_in_scope("table", Scope::Button));
+        assert!(parser.is_in_scope("table", Scope::Table));
+        assert!(!parser.is_in_scope("table", Scope::Select));
     }
 
     #[test]
@@ -3659,11 +3659,11 @@ mod test {
         node_create!(parser, "optgroup");
         node_create!(parser, "option");
 
-        assert_eq!(parser.is_in_scope("select", Scope::Regular), true);
-        assert_eq!(parser.is_in_scope("select", Scope::ListItem), true);
-        assert_eq!(parser.is_in_scope("select", Scope::Button), true);
-        assert_eq!(parser.is_in_scope("select", Scope::Table), true);
-        assert_eq!(parser.is_in_scope("select", Scope::Select), true);
+        assert!(parser.is_in_scope("select", Scope::Regular));
+        assert!(parser.is_in_scope("select", Scope::ListItem));
+        assert!(parser.is_in_scope("select", Scope::Button));
+        assert!(parser.is_in_scope("select", Scope::Table));
+        assert!(parser.is_in_scope("select", Scope::Select));
     }
 
     #[test]

--- a/src/testing/tokenizer.rs
+++ b/src/testing/tokenizer.rs
@@ -1,12 +1,15 @@
-use regex::Regex;
+use lazy_static::lazy_static;
+use regex::{Captures, Regex};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::{cell::RefCell, rc::Rc};
 use std::{
     fs,
     path::{Path, PathBuf},
 };
 
+use crate::html5_parser::tokenizer::token::{Attribute, Token, TokenType};
 use crate::html5_parser::{
     error_logger::ErrorLogger,
     input_stream::InputStream,
@@ -90,7 +93,7 @@ impl Test {
 
             let mut is = InputStream::new();
             let input = if self.double_escaped.unwrap_or(false) {
-                escape(self.input.as_str())
+                from_utf16_lossy(self.input.as_str())
             } else {
                 self.input.to_string()
             };
@@ -107,17 +110,261 @@ impl Test {
 
         builders
     }
+
+    pub fn assert_valid(&self) {
+        for mut builder in self.builders() {
+            let mut tokenizer = builder.build();
+
+            // If there is no output, still do an (initial) next token so the parser can generate
+            // errors.
+            if self.output.is_empty() {
+                tokenizer.next_token();
+            }
+
+            // There can be multiple tokens to match. Make sure we match all of them
+            for expected_token in self.output.iter() {
+                let t = tokenizer.next_token();
+                self.assert_token(t, expected_token);
+            }
+
+            let borrowed_error_logger = tokenizer.error_logger.borrow();
+            assert_eq!(borrowed_error_logger.get_errors().len(), self.errors.len());
+
+            // Check error messages
+            for error in &self.errors {
+                self.assert_error(&tokenizer, error);
+            }
+        }
+    }
+
+    // Run through the parsing without making assertions, for use in benchmarking and in order to
+    // disclose any panics that might happen
+    pub fn tokenize(&self) {
+        for mut builder in self.builders() {
+            let mut tokenizer = builder.build();
+
+            for _ in self.output.iter() {
+                tokenizer.next_token();
+            }
+        }
+    }
+
+    fn assert_error(&self, tokenizer: &Tokenizer, expected: &Error) {
+        // Iterate all generated errors to see if we have an exact match
+        for actual in tokenizer.get_error_logger().get_errors() {
+            if actual.message == expected.code
+                && actual.line as i64 == expected.line
+                && actual.col as i64 == expected.col
+            {
+                return;
+            }
+        }
+
+        // Try and find an error that matches the code, but has a different line/pos. Even though
+        // it's not always correct, it might be a off-by-one position.
+        for actual in tokenizer.get_error_logger().get_errors() {
+            if actual.message == expected.code
+                && (actual.line as i64 != expected.line || actual.col as i64 != expected.col)
+            {
+                panic!(
+                    "[{}]: wanted {:?}, got {:?}",
+                    self.description, expected, actual
+                );
+            }
+        }
+
+        panic!(
+            "expected error '{}' at {}:{}",
+            expected.code, expected.line, expected.col
+        );
+    }
+
+    fn assert_token(&self, have: Token, expected: &[Value]) {
+        use crate::html5_parser::tokenizer::token::TokenTrait;
+
+        let double_escaped = self.double_escaped.unwrap_or(false);
+
+        let tp = expected.get(0).unwrap();
+
+        let expected_token_type = match tp.as_str().unwrap() {
+            "DOCTYPE" => TokenType::DocTypeToken,
+            "StartTag" => TokenType::StartTagToken,
+            "EndTag" => TokenType::EndTagToken,
+            "Comment" => TokenType::CommentToken,
+            "Character" => TokenType::TextToken,
+            _ => panic!("unknown output token type {:?}", tp.as_str().unwrap()),
+        };
+
+        assert_eq!(
+            have.type_of(),
+            expected_token_type,
+            "incorrect token type found (want: {:?}, got {:?})",
+            expected_token_type,
+            have.type_of(),
+        );
+
+        match have {
+            Token::DocTypeToken {
+                name,
+                force_quirks,
+                pub_identifier,
+                sys_identifier,
+            } => self.assert_doctype(expected, name, force_quirks, pub_identifier, sys_identifier),
+            Token::StartTagToken {
+                name,
+                attributes,
+                is_self_closing,
+            } => self.assert_starttag(expected, &name, attributes, is_self_closing),
+            Token::EndTagToken { name, .. } => self.assert_endtag(expected, &name, double_escaped),
+            Token::CommentToken { value } => self.assert_comment(expected, &value, double_escaped),
+            Token::TextToken { value } => self.assert_text(expected, &value, double_escaped),
+            Token::EofToken => panic!("expected eof token"),
+        }
+    }
+
+    fn assert_starttag(
+        &self,
+        expected: &[Value],
+        name: &str,
+        attributes: HashMap<String, String>,
+        is_self_closing: bool,
+    ) {
+        let expected_name = expected.get(1).and_then(|v| v.as_str()).unwrap();
+        let expected_attrs = expected.get(2).and_then(|v| v.as_object());
+        let expected_self_closing = expected.get(3).and_then(|v| v.as_bool());
+
+        assert_eq!(expected_name, name, "incorrect start tag");
+
+        if let Some(expected_self_closing) = expected_self_closing {
+            assert_eq!(
+                expected_self_closing, is_self_closing,
+                "incorrect start tag (expected self-closing)"
+            );
+        }
+
+        if expected_attrs.is_none() && attributes.is_empty() {
+            // No attributes to check
+            return;
+        }
+
+        // Convert the expected attr to Vec<(string, string)>
+        let expected_attrs: Vec<Attribute> = expected_attrs.map_or(Vec::new(), |map| {
+            map.iter()
+                .filter_map(|(key, value)| {
+                    value.as_str().map(|v| Attribute {
+                        name: key.clone(),
+                        value: v.to_string(),
+                    })
+                })
+                .collect()
+        });
+
+        let attributes: Vec<Attribute> = attributes
+            .iter()
+            .map(|(key, value)| Attribute {
+                name: key.clone(),
+                value: value.clone(),
+            })
+            .collect();
+
+        let set1: HashSet<_> = expected_attrs.iter().collect();
+        let set2: HashSet<_> = attributes.iter().collect();
+
+        assert_eq!(set1, set2, "attribute mismatch");
+    }
+
+    fn assert_comment(&self, expected: &[Value], value: &str, is_double_escaped: bool) {
+        let output_ref = expected.get(1).unwrap().as_str().unwrap();
+        let output = if is_double_escaped {
+            from_utf16_lossy(output_ref)
+        } else {
+            output_ref.to_string()
+        };
+
+        assert_eq!(value, output, "incorrect text found in comment token");
+    }
+
+    fn assert_text(&self, expected: &[Value], value: &str, is_double_escaped: bool) {
+        let output_ref = expected.get(1).unwrap().as_str().unwrap();
+        let output = if is_double_escaped {
+            from_utf16_lossy(output_ref)
+        } else {
+            output_ref.to_string()
+        };
+
+        assert_eq!(value, output, "incorrect text found in text token",);
+    }
+
+    fn assert_endtag(&self, expected: &[Value], name: &str, is_double_escaped: bool) {
+        let output_ref = expected.get(1).unwrap().as_str().unwrap();
+        let output = if is_double_escaped {
+            from_utf16_lossy(output_ref)
+        } else {
+            output_ref.to_string()
+        };
+
+        assert_eq!(name, output, "incorrect end tag");
+    }
+
+    // Check if a given doctype matches the expected result
+    fn assert_doctype(
+        &self,
+        expected: &[Value],
+        name: Option<String>,
+        force_quirks: bool,
+        pub_identifier: Option<String>,
+        sys_identifier: Option<String>,
+    ) {
+        let expected_name = expected[1].as_str();
+        let expected_pub = expected[2].as_str();
+        let expected_sys = expected[3].as_str();
+        let expected_quirk = expected[4].as_bool();
+
+        assert_eq!(expected_name, name.as_deref(), "incorrect doctype");
+
+        if let Some(expected_quirk) = expected_quirk {
+            assert_ne!(
+                expected_quirk, force_quirks,
+                "incorrect doctype (wanted quirk: {})",
+                expected_quirk
+            );
+        }
+
+        assert_eq!(
+            expected_pub,
+            pub_identifier.as_deref(),
+            "incorrect doctype (wanted pub id: '{:?}', got '{:?}')",
+            expected_pub,
+            pub_identifier,
+        );
+
+        assert_eq!(
+            expected_sys,
+            sys_identifier.as_deref(),
+            "incorrect doctype (wanted sys id: '{:?}', got '{:?}')",
+            expected_sys,
+            sys_identifier
+        );
+    }
 }
 
-pub fn escape(input: &str) -> String {
-    let re = Regex::new(r"\\u([0-9a-fA-F]{4})").unwrap();
-    re.replace_all(input, |caps: &regex::Captures| {
-        let hex_val = u32::from_str_radix(&caps[1], 16).unwrap();
+pub fn from_utf16_lossy(input: &str) -> String {
+    // TODO: Maybe use String::from_utf8_lossy(input.as_bytes()).into() instead
+    // https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf8_lossy
 
-        // This will also convert surrogates?
-        unsafe { char::from_u32_unchecked(hex_val).to_string() }
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r"\\u([0-9a-fA-F]{4})").unwrap();
+    }
+
+    RE.replace_all(input, |cap: &Captures| {
+        let n = u16::from_str_radix(&cap[1], 16).unwrap();
+        // There are UTF-16 characters that the following will not decode into UTF-8, so we might
+        // be dropping characters when a DecodeUtf16Error error is encountered.
+        std::char::decode_utf16([n])
+            .filter_map(|r| r.ok())
+            .collect::<String>()
     })
-    .into_owned()
+    .to_string()
 }
 
 pub fn fixture_from_filename(filename: &str) -> Result<Root, serde_json::Error> {

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -1,227 +1,39 @@
-use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use lazy_static::lazy_static;
+use std::collections::HashSet;
 use test_case::test_case;
 
-use gosub_engine::html5_parser::tokenizer::token::{Attribute, Token, TokenTrait, TokenType};
-use gosub_engine::html5_parser::tokenizer::Tokenizer;
-use gosub_engine::testing::tokenizer::{self, escape, Error, Test};
+use gosub_engine::testing::tokenizer;
 
-fn assert_tokenization(test: &Test) {
-    for mut builder in test.builders() {
-        let mut tokenizer = builder.build();
+const DISABLED_CASES: &[&str] = &[
+    // TODO: Handle UTF-16 high and low private surrogate characters
+    // https://www.compart.com/en/unicode/U+DBC0
+    // https://www.compart.com/en/unicode/U+DC00
+    ";\\uDBC0\\uDC00",
+    "<!-- -\\uDBC0\\uDC00",
+    "<!-- \\uDBC0\\uDC00",
+    "<!----\\uDBC0\\uDC00",
+    "<!---\\uDBC0\\uDC00",
+    "<!--\\uDBC0\\uDC00",
+    "<!DOCTYPE a PUBLIC\"\\uDBC0\\uDC00",
+    "<!DOCTYPE a PUBLIC'\\uDBC0\\uDC00",
+    "<!DOCTYPE a SYSTEM\"\\uDBC0\\uDC00",
+    "<!DOCTYPE a SYSTEM'\\uDBC0\\uDC00",
+    "<!DOCTYPE a\\uDBC0\\uDC00",
+    "<!DOCTYPE \\uDBC0\\uDC00",
+    "<!DOCTYPEa PUBLIC\"\\uDBC0\\uDC00",
+    "<!DOCTYPEa PUBLIC'\\uDBC0\\uDC00",
+    "<!DOCTYPEa SYSTEM\"\\uDBC0\\uDC00",
+    "<!DOCTYPEa SYSTEM'\\uDBC0\\uDC00",
+    "<!DOCTYPEa\\uDBC0\\uDC00",
+    "<!DOCTYPE\\uDBC0\\uDC00",
+    "\\uDBC0\\uDC00",
+];
 
-        // If there is no output, still do an (initial) next token so the parser can generate
-        // errors.
-        if test.output.is_empty() {
-            tokenizer.next_token();
-        }
-
-        // There can be multiple tokens to match. Make sure we match all of them
-        for expected_token in test.output.iter() {
-            let t = tokenizer.next_token();
-            assert_token(t, expected_token, test.double_escaped.unwrap_or(false));
-        }
-
-        let borrowed_error_logger = tokenizer.error_logger.borrow();
-        assert_eq!(borrowed_error_logger.get_errors().len(), test.errors.len());
-
-        // Check error messages
-        for error in &test.errors {
-            assert_error(&tokenizer, error);
-        }
-    }
-}
-
-fn assert_error(tokenizer: &Tokenizer, expected_err: &Error) {
-    // Iterate all generated errors to see if we have an exact match
-    for got_err in tokenizer.get_error_logger().get_errors() {
-        if got_err.message == expected_err.code
-            && got_err.line as i64 == expected_err.line
-            && got_err.col as i64 == expected_err.col
-        {
-            return;
-        }
-    }
-
-    // Try and find an error that matches the code, but has a different line/pos. Even though
-    // it's not always correct, it might be a off-by-one position.
-    for got_err in tokenizer.get_error_logger().get_errors() {
-        if got_err.message == expected_err.code
-            && (got_err.line as i64 != expected_err.line || got_err.col as i64 != expected_err.col)
-        {
-            panic!(
-                "expected error '{}' at {}:{}",
-                expected_err.code, expected_err.line, expected_err.col
-            );
-        }
-    }
-
-    panic!(
-        "expected error '{}' at {}:{}",
-        expected_err.code, expected_err.line, expected_err.col
-    );
-}
-
-fn assert_token(have: Token, expected: &[Value], double_escaped: bool) {
-    let tp = expected.get(0).unwrap();
-
-    let expected_token_type = match tp.as_str().unwrap() {
-        "DOCTYPE" => TokenType::DocTypeToken,
-        "StartTag" => TokenType::StartTagToken,
-        "EndTag" => TokenType::EndTagToken,
-        "Comment" => TokenType::CommentToken,
-        "Character" => TokenType::TextToken,
-        _ => panic!("unknown output token type {:?}", tp.as_str().unwrap()),
-    };
-
-    assert_eq!(
-        have.type_of(),
-        expected_token_type,
-        "incorrect token type found (want: {:?}, got {:?})",
-        expected_token_type,
-        have.type_of(),
-    );
-
-    match have {
-        Token::DocTypeToken {
-            name,
-            force_quirks,
-            pub_identifier,
-            sys_identifier,
-        } => assert_doctype(expected, name, force_quirks, pub_identifier, sys_identifier),
-        Token::StartTagToken {
-            name,
-            attributes,
-            is_self_closing,
-        } => assert_starttag(expected, &name, attributes, is_self_closing),
-        Token::EndTagToken { name, .. } => assert_endtag(expected, &name, double_escaped),
-        Token::CommentToken { value } => assert_comment(expected, &value, double_escaped),
-        Token::TextToken { value } => assert_text(expected, &value, double_escaped),
-        Token::EofToken => panic!("expected eof token"),
-    }
-}
-
-fn assert_starttag(
-    expected: &[Value],
-    name: &str,
-    attributes: HashMap<String, String>,
-    is_self_closing: bool,
-) {
-    let expected_name = expected.get(1).and_then(|v| v.as_str()).unwrap();
-    let expected_attrs = expected.get(2).and_then(|v| v.as_object());
-    let expected_self_closing = expected.get(3).and_then(|v| v.as_bool());
-
-    assert_eq!(expected_name, name, "incorrect start tag");
-
-    if let Some(expected_self_closing) = expected_self_closing {
-        assert_eq!(
-            expected_self_closing, is_self_closing,
-            "incorrect start tag (expected self-closing)"
-        );
-    }
-
-    if expected_attrs.is_none() && attributes.is_empty() {
-        // No attributes to check
-        return;
-    }
-
-    // Convert the expected attr to Vec<(string, string)>
-    let expected_attrs: Vec<Attribute> = expected_attrs.map_or(Vec::new(), |map| {
-        map.iter()
-            .filter_map(|(key, value)| {
-                value.as_str().map(|v| Attribute {
-                    name: key.clone(),
-                    value: v.to_string(),
-                })
-            })
-            .collect()
-    });
-
-    let attributes: Vec<Attribute> = attributes
+lazy_static! {
+    static ref DISABLED: HashSet<String> = DISABLED_CASES
         .iter()
-        .map(|(key, value)| Attribute {
-            name: key.clone(),
-            value: value.clone(),
-        })
-        .collect();
-
-    let set1: HashSet<_> = expected_attrs.iter().collect();
-    let set2: HashSet<_> = attributes.iter().collect();
-
-    assert_eq!(set1, set2, "attribute mismatch");
-}
-
-fn assert_comment(expected: &[Value], value: &str, is_double_escaped: bool) {
-    let output_ref = expected.get(1).unwrap().as_str().unwrap();
-    let output = if is_double_escaped {
-        escape(output_ref)
-    } else {
-        output_ref.to_string()
-    };
-
-    assert_eq!(value, output, "incorrect text found in comment token");
-}
-
-fn assert_text(expected: &[Value], value: &str, is_double_escaped: bool) {
-    let output_ref = expected.get(1).unwrap().as_str().unwrap();
-    let output = if is_double_escaped {
-        escape(output_ref)
-    } else {
-        output_ref.to_string()
-    };
-
-    assert_eq!(value, output, "incorrect text found in text token",);
-}
-
-fn assert_endtag(expected: &[Value], name: &str, is_double_escaped: bool) {
-    let output_ref = expected.get(1).unwrap().as_str().unwrap();
-    let output = if is_double_escaped {
-        escape(output_ref)
-    } else {
-        output_ref.to_string()
-    };
-
-    assert_eq!(name, output, "incorrect end tag");
-}
-
-// Check if a given doctype matches the expected result
-fn assert_doctype(
-    expected: &[Value],
-    name: Option<String>,
-    force_quirks: bool,
-    pub_identifier: Option<String>,
-    sys_identifier: Option<String>,
-) {
-    let expected_name = expected[1].as_str();
-    let expected_pub = expected[2].as_str();
-    let expected_sys = expected[3].as_str();
-    let expected_quirk = expected[4].as_bool();
-
-    assert_eq!(expected_name, name.as_deref(), "incorrect doctype");
-
-    if let Some(expected_quirk) = expected_quirk {
-        assert_ne!(
-            expected_quirk, force_quirks,
-            "incorrect doctype (wanted quirk: {})",
-            expected_quirk
-        );
-    }
-
-    assert_eq!(
-        expected_pub,
-        pub_identifier.as_deref(),
-        "incorrect doctype (wanted pub id: '{:?}', got '{:?}')",
-        expected_pub,
-        pub_identifier,
-    );
-
-    assert_eq!(
-        expected_sys,
-        sys_identifier.as_deref(),
-        "incorrect doctype (wanted sys id: '{:?}', got '{:?}')",
-        expected_sys,
-        sys_identifier
-    );
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
 }
 
 #[test_case("contentModelFlags.test")]
@@ -233,14 +45,21 @@ fn assert_doctype(
 #[test_case("pendingSpecChanges.test")]
 #[test_case("test1.test")]
 #[test_case("test2.test")]
-// #[test_case("test3.test")]
+#[test_case("test3.test")]
 #[test_case("test4.test")]
 // #[test_case("unicodeCharsProblematic.test")]
 #[test_case("unicodeChars.test")]
 // #[test_case("xmlViolation.test")]
 fn tokenization(filename: &str) {
-    let root = tokenizer::fixture_from_filename(&filename).unwrap();
+    let root = tokenizer::fixture_from_filename(filename).unwrap();
+
     for test in root.tests {
-        assert_tokenization(&test)
+        if DISABLED.contains(&test.description) {
+            // Check that we don't panic
+            test.tokenize();
+            continue;
+        }
+
+        test.assert_valid();
     }
 }


### PR DESCRIPTION
This PR
* Enables another tokenization test file from the vendored test suite
* Replaces the conversion of UTF-16 characters using `unsafe` with one that doesn't use `unsafe`
* Runs `cargo clippy --fix`
