### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds [Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/), which, if you haven't used it before, configures GitHub to open PRs to upgrade (Rust) dependencies when updates come out.  This can help to avoid falling too far behind with library versions and to easily pick up security updates.

I configured Dependabot to run weekly, but, eventually, once people seem to be on top of the PRs, we can change it to daily.