### PR TITLE
Split `Node.data` into structs

### DIFF
--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -302,16 +302,16 @@ fn match_node(
     if node_idx.is_positive() {
         match &node.data {
             NodeData::Element(element) => {
-                let element_name: String = element.get_name();
                 let value = format!(
                     "|{}<{}>",
                     " ".repeat((indent as usize * 2) + 1),
-                    element_name
+                    element.name()
                 );
                 if value != expected[expected_id as usize] {
                     println!(
                         "❌ {}, Found unexpected element node: {}",
-                        expected[expected_id as usize], element_name
+                        expected[expected_id as usize],
+                        element.name()
                     );
                     return None;
                 } else {
@@ -319,12 +319,16 @@ fn match_node(
                 }
             }
             NodeData::Text(text) => {
-                let text_value: String = text.get_value();
-                let value = format!("|{}\"{}\"", " ".repeat(indent as usize * 2 + 1), text_value);
+                let value = format!(
+                    "|{}\"{}\"",
+                    " ".repeat(indent as usize * 2 + 1),
+                    text.value()
+                );
                 if value != expected[expected_id as usize] {
                     println!(
                         "❌ {}, Found unexpected text node: {}",
-                        expected[expected_id as usize], value
+                        expected[expected_id as usize],
+                        text.value()
                     );
                     return None;
                 } else {

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -311,7 +311,7 @@ fn match_node(
                 if value != expected[expected_id as usize] {
                     println!(
                         "❌ {}, Found unexpected element node: {}",
-                        expected[expected_id as usize], value
+                        expected[expected_id as usize], element_name
                     );
                     return None;
                 } else {

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -303,7 +303,11 @@ fn match_node(
         match &node.data {
             NodeData::Element(element) => {
                 let element_name: String = element.get_name();
-                let value = format!("|{}<{}>", " ".repeat((indent as usize * 2) + 1), element_name);
+                let value = format!(
+                    "|{}<{}>",
+                    " ".repeat((indent as usize * 2) + 1),
+                    element_name
+                );
                 if value != expected[expected_id as usize] {
                     println!(
                         "❌ {}, Found unexpected element node: {}",
@@ -314,13 +318,13 @@ fn match_node(
                     println!("✅  {}", expected[expected_id as usize]);
                 }
             }
-            NodeData::Text(text)  => {
+            NodeData::Text(text) => {
                 let text_value: String = text.get_value();
                 let value = format!("|{}\"{}\"", " ".repeat(indent as usize * 2 + 1), text_value);
                 if value != expected[expected_id as usize] {
                     println!(
                         "❌ {}, Found unexpected text node: {}",
-                        expected[expected_id as usize], value 
+                        expected[expected_id as usize], value
                     );
                     return None;
                 } else {

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -301,24 +301,26 @@ fn match_node(
 
     if node_idx.is_positive() {
         match &node.data {
-            NodeData::Element { name, .. } => {
-                let value = format!("|{}<{}>", " ".repeat((indent as usize * 2) + 1), name);
+            NodeData::Element(element) => {
+                let element_name: String = element.get_name();
+                let value = format!("|{}<{}>", " ".repeat((indent as usize * 2) + 1), element_name);
                 if value != expected[expected_id as usize] {
                     println!(
                         "❌ {}, Found unexpected element node: {}",
-                        expected[expected_id as usize], name
+                        expected[expected_id as usize], value
                     );
                     return None;
                 } else {
                     println!("✅  {}", expected[expected_id as usize]);
                 }
             }
-            NodeData::Text { value } => {
-                let value = format!("|{}\"{}\"", " ".repeat(indent as usize * 2 + 1), value);
+            NodeData::Text(text)  => {
+                let text_value: String = text.get_value();
+                let value = format!("|{}\"{}\"", " ".repeat(indent as usize * 2 + 1), text_value);
                 if value != expected[expected_id as usize] {
                     println!(
                         "❌ {}, Found unexpected text node: {}",
-                        expected[expected_id as usize], value
+                        expected[expected_id as usize], value 
                     );
                     return None;
                 } else {

--- a/src/bin/test-user-agent.rs
+++ b/src/bin/test-user-agent.rs
@@ -90,9 +90,8 @@ fn get_node_by_path<'a>(document: &'a Document, path: Vec<&'a str>) -> Option<&'
 
 fn display_node(document: &Document, node: &Node) {
     if let NodeData::Text(text) = &node.data {
-        let text_value: String = text.get_value();
-        if !text_value.eq("\n") {
-            println!("{}", text_value);
+        if !text.value().eq("\n") {
+            println!("{}", text.value());
         }
     }
     for child_id in &node.children {

--- a/src/bin/test-user-agent.rs
+++ b/src/bin/test-user-agent.rs
@@ -89,9 +89,10 @@ fn get_node_by_path<'a>(document: &'a Document, path: Vec<&'a str>) -> Option<&'
 }
 
 fn display_node(document: &Document, node: &Node) {
-    if let NodeData::Text { value } = &node.data {
-        if !value.eq("\n") {
-            println!("{}", value);
+    if let NodeData::Text(text) = &node.data {
+        let text_value: String = text.get_value();
+        if !text_value.eq("\n") {
+            println!("{}", text_value);
         }
     }
     for child_id in &node.children {

--- a/src/html5_parser.rs
+++ b/src/html5_parser.rs
@@ -3,6 +3,7 @@ pub mod element_class;
 pub mod error_logger;
 pub mod input_stream;
 pub mod node;
+pub mod node_data;
 mod node_arena;
 pub mod parser;
 pub mod tokenizer;

--- a/src/html5_parser.rs
+++ b/src/html5_parser.rs
@@ -3,7 +3,7 @@ pub mod element_class;
 pub mod error_logger;
 pub mod input_stream;
 pub mod node;
-pub mod node_data;
 mod node_arena;
+pub mod node_data;
 pub mod parser;
 pub mod tokenizer;

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -366,8 +366,8 @@ mod tests {
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         match &node.data {
-            NodeData::Document(_) => assert!(true),
-            _ => unreachable!(),
+            NodeData::Document(_) => (),
+            _ => panic!(),
         }
     }
 
@@ -387,7 +387,7 @@ mod tests {
                 assert!(element.attributes.contains("id"));
                 assert_eq!(element.attributes.get("id").unwrap(), "test");
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -403,7 +403,7 @@ mod tests {
             NodeData::Comment(comment) => {
                 assert_eq!(comment.get_value(), "test");
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -419,7 +419,7 @@ mod tests {
             NodeData::Text(text) => {
                 assert_eq!(text.get_value(), "test");
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -501,7 +501,7 @@ mod tests {
                 assert!(element.attributes.contains("x"));
                 assert!(!element.attributes.contains("z"));
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -515,7 +515,7 @@ mod tests {
                 element.attributes.insert("key", "value");
                 assert_eq!(element.attributes.get("key").unwrap(), "value");
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -531,7 +531,7 @@ mod tests {
                 element.attributes.remove("key");
                 assert!(!element.attributes.contains("key"));
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -546,7 +546,7 @@ mod tests {
             NodeData::Element(element) => {
                 assert_eq!(element.attributes.get("key").unwrap(), "value");
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -564,7 +564,7 @@ mod tests {
 
                 assert_eq!(element.attributes.get("key").unwrap(), "value appended");
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -580,7 +580,7 @@ mod tests {
                 element.attributes.clear();
                 assert!(element.attributes.is_empty());
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 
@@ -596,7 +596,7 @@ mod tests {
                 element.attributes.insert("key", "value");
                 assert!(!element.attributes.is_empty());
             }
-            _ => unreachable!(),
+            _ => panic!(),
         }
     }
 }

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -1,8 +1,8 @@
 use crate::html5_parser::element_class::ElementClass;
-use crate::html5_parser::node_data::document_data::DocumentData;
-use crate::html5_parser::node_data::text_data::TextData;
 use crate::html5_parser::node_data::comment_data::CommentData;
+use crate::html5_parser::node_data::document_data::DocumentData;
 use crate::html5_parser::node_data::element_data::ElementData;
+use crate::html5_parser::node_data::text_data::TextData;
 use derive_more::Display;
 use std::collections::HashMap;
 
@@ -146,7 +146,7 @@ impl Node {
             named_id: None,
             parent: None,
             children: vec![],
-            data: NodeData::Element(ElementData::new_with_name_and_attributes(name, attributes)), 
+            data: NodeData::Element(ElementData::new_with_name_and_attributes(name, attributes)),
             name: name.to_string(),
             namespace: Some(namespace.into()),
             classes: Some(ElementClass::new()),
@@ -160,7 +160,7 @@ impl Node {
             named_id: None,
             parent: None,
             children: vec![],
-            data: NodeData::Comment(CommentData::new_with_value(value)), 
+            data: NodeData::Comment(CommentData::new_with_value(value)),
             name: "".to_string(),
             namespace: None,
             classes: None,
@@ -366,8 +366,8 @@ mod tests {
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         match &node.data {
-            NodeData::Document(document) => assert!(true),
-            _ => assert!(false)
+            NodeData::Document(_) => assert!(true),
+            _ => assert!(false),
         }
     }
 
@@ -386,7 +386,7 @@ mod tests {
                 assert_eq!(element.get_name(), "div");
                 assert!(element.attributes.contains("id"));
                 assert_eq!(element.attributes.get("id").unwrap(), "test");
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -402,7 +402,7 @@ mod tests {
         match &node.data {
             NodeData::Comment(comment) => {
                 assert_eq!(comment.get_value(), "test");
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -418,7 +418,7 @@ mod tests {
         match &node.data {
             NodeData::Text(text) => {
                 assert_eq!(text.get_value(), "test");
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -500,7 +500,7 @@ mod tests {
             NodeData::Element(element) => {
                 assert!(element.attributes.contains("x"));
                 assert!(!element.attributes.contains("z"));
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -514,7 +514,7 @@ mod tests {
             NodeData::Element(element) => {
                 element.attributes.insert("key", "value");
                 assert_eq!(element.attributes.get("key").unwrap(), "value");
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -530,7 +530,7 @@ mod tests {
             NodeData::Element(element) => {
                 element.attributes.remove("key");
                 assert!(!element.attributes.contains("key"));
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -545,7 +545,7 @@ mod tests {
         match &node.data {
             NodeData::Element(element) => {
                 assert_eq!(element.attributes.get("key").unwrap(), "value");
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -559,11 +559,11 @@ mod tests {
 
         match &mut node.data {
             NodeData::Element(element) => {
-                let mut attr_val = element.attributes.get_mut("key").unwrap();
+                let attr_val = element.attributes.get_mut("key").unwrap();
                 attr_val.push_str(" appended");
 
                 assert_eq!(element.attributes.get("key").unwrap(), "value appended");
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -579,7 +579,7 @@ mod tests {
             NodeData::Element(element) => {
                 element.attributes.clear();
                 assert!(element.attributes.is_empty());
-            },
+            }
             _ => assert!(false),
         }
     }
@@ -595,7 +595,7 @@ mod tests {
                 assert!(element.attributes.is_empty());
                 element.attributes.insert("key", "value");
                 assert!(!element.attributes.is_empty());
-            },
+            }
             _ => assert!(false),
         }
     }

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -134,7 +134,7 @@ impl Node {
             named_id: None,
             parent: None,
             children: vec![],
-            data: NodeData::Document {},
+            data: NodeData::Document(DocumentData::new()),
             name: "".to_string(),
             namespace: None,
             classes: None,
@@ -148,10 +148,7 @@ impl Node {
             named_id: None,
             parent: None,
             children: vec![],
-            data: NodeData::Element {
-                name: name.to_string(),
-                attributes,
-            },
+            data: NodeData::Element(ElementData::new_with_name_and_attributes(name, attributes)), 
             name: name.to_string(),
             namespace: Some(namespace.into()),
             classes: Some(ElementClass::new()),
@@ -165,9 +162,7 @@ impl Node {
             named_id: None,
             parent: None,
             children: vec![],
-            data: NodeData::Comment {
-                value: value.to_string(),
-            },
+            data: NodeData::Comment(CommentData::new_with_value(value)), 
             name: "".to_string(),
             namespace: None,
             classes: None,
@@ -181,9 +176,7 @@ impl Node {
             named_id: None,
             parent: None,
             children: vec![],
-            data: NodeData::Text {
-                value: value.to_string(),
-            },
+            data: NodeData::Text(TextData::new_with_value(value)),
             name: "".to_string(),
             namespace: None,
             classes: None,
@@ -230,8 +223,9 @@ impl Node {
     pub fn set_named_id(&mut self, named_id: &str) {
         if self.type_of() == NodeType::Element {
             self.named_id = Some(named_id.to_owned());
-            // TODO: log a warning/error if this fails for some reason
-            let _ = self.insert_attribute("id", named_id);
+            if let NodeData::Element(element) = &mut self.data {
+                element.attributes.insert("id", named_id);
+            }
         }
     }
 

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -367,7 +367,7 @@ mod tests {
         assert_eq!(node.namespace, None);
         match &node.data {
             NodeData::Document(_) => assert!(true),
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -387,7 +387,7 @@ mod tests {
                 assert!(element.attributes.contains("id"));
                 assert_eq!(element.attributes.get("id").unwrap(), "test");
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -403,7 +403,7 @@ mod tests {
             NodeData::Comment(comment) => {
                 assert_eq!(comment.get_value(), "test");
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -419,7 +419,7 @@ mod tests {
             NodeData::Text(text) => {
                 assert_eq!(text.get_value(), "test");
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -501,7 +501,7 @@ mod tests {
                 assert!(element.attributes.contains("x"));
                 assert!(!element.attributes.contains("z"));
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -515,7 +515,7 @@ mod tests {
                 element.attributes.insert("key", "value");
                 assert_eq!(element.attributes.get("key").unwrap(), "value");
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -531,7 +531,7 @@ mod tests {
                 element.attributes.remove("key");
                 assert!(!element.attributes.contains("key"));
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -546,7 +546,7 @@ mod tests {
             NodeData::Element(element) => {
                 assert_eq!(element.attributes.get("key").unwrap(), "value");
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -564,7 +564,7 @@ mod tests {
 
                 assert_eq!(element.attributes.get("key").unwrap(), "value appended");
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -580,7 +580,7 @@ mod tests {
                 element.attributes.clear();
                 assert!(element.attributes.is_empty());
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -596,7 +596,7 @@ mod tests {
                 element.attributes.insert("key", "value");
                 assert!(!element.attributes.is_empty());
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 }

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -1,4 +1,8 @@
 use crate::html5_parser::element_class::ElementClass;
+use crate::html5_parser::node_data::document_data::DocumentData;
+use crate::html5_parser::node_data::text_data::TextData;
+use crate::html5_parser::node_data::comment_data::CommentData;
+use crate::html5_parser::node_data::element_data::ElementData;
 use derive_more::Display;
 use std::collections::HashMap;
 
@@ -23,17 +27,10 @@ pub enum NodeType {
 /// Different type of node data
 #[derive(Debug, PartialEq, Clone)]
 pub enum NodeData {
-    Document,
-    Text {
-        value: String,
-    },
-    Comment {
-        value: String,
-    },
-    Element {
-        name: String,
-        attributes: HashMap<String, String>,
-    },
+    Document(DocumentData),
+    Text(TextData),
+    Comment(CommentData),
+    Element(ElementData),
 }
 
 /// Id used to identify a node
@@ -250,104 +247,6 @@ impl Node {
 
         // don't want to return the actual internal String
         self.named_id.clone()
-    }
-
-    /// Check if an attribute exists
-    pub fn contains_attribute(&self, name: &str) -> Result<bool, String> {
-        if self.type_of() != NodeType::Element {
-            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
-        }
-
-        let contains: bool = match &self.data {
-            NodeData::Element { attributes, .. } => attributes.contains_key(name),
-            _ => false,
-        };
-
-        Ok(contains)
-    }
-
-    /// Add or update a an attribute
-    pub fn insert_attribute(&mut self, name: &str, value: &str) -> Result<(), String> {
-        if self.type_of() != NodeType::Element {
-            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
-        }
-
-        if let NodeData::Element { attributes, .. } = &mut self.data {
-            attributes.insert(name.to_owned(), value.to_owned());
-        }
-
-        Ok(())
-    }
-
-    /// Remove an attribute. If attribute doesn't exist, nothing happens.
-    pub fn remove_attribute(&mut self, name: &str) -> Result<(), String> {
-        if self.type_of() != NodeType::Element {
-            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
-        }
-
-        if let NodeData::Element { attributes, .. } = &mut self.data {
-            attributes.remove(name);
-        }
-
-        Ok(())
-    }
-
-    /// Get a constant reference to the attribute value
-    /// (or None if attribute doesn't exist)
-    pub fn get_attribute(&self, name: &str) -> Option<&String> {
-        if self.type_of() != NodeType::Element {
-            return None;
-        }
-
-        let mut value: Option<&String> = None;
-        if let NodeData::Element { attributes, .. } = &self.data {
-            value = attributes.get(name);
-        }
-
-        value
-    }
-
-    /// Get a mutable reference to the attribute value
-    /// (or None if the attribute doesn't exist)
-    pub fn get_mut_attribute(&mut self, name: &str) -> Option<&mut String> {
-        if self.type_of() != NodeType::Element {
-            return None;
-        }
-
-        let mut value: Option<&mut String> = None;
-        if let NodeData::Element { attributes, .. } = &mut self.data {
-            value = attributes.get_mut(name);
-        }
-
-        value
-    }
-
-    /// Remove all attributes
-    pub fn clear_attributes(&mut self) -> Result<(), String> {
-        if self.type_of() != NodeType::Element {
-            return Err(String::from(ATTRIBUTE_NODETYPE_ERR_MSG));
-        }
-
-        if let NodeData::Element { attributes, .. } = &mut self.data {
-            attributes.clear();
-        }
-
-        Ok(())
-    }
-
-    /// Check if node has any attributes
-    /// (NOTE: if node is not Element type, returns false anyways)
-    pub fn has_attributes(&self) -> bool {
-        if self.type_of() != NodeType::Element {
-            return false;
-        }
-
-        let mut has_attr: bool = false;
-        if let NodeData::Element { attributes, .. } = &self.data {
-            has_attr = !attributes.is_empty();
-        }
-
-        has_attr
     }
 }
 

--- a/src/html5_parser/node_data.rs
+++ b/src/html5_parser/node_data.rs
@@ -1,0 +1,4 @@
+pub mod document_data;
+pub mod element_data;
+pub mod text_data;
+pub mod comment_data;

--- a/src/html5_parser/node_data.rs
+++ b/src/html5_parser/node_data.rs
@@ -1,4 +1,4 @@
+pub mod comment_data;
 pub mod document_data;
 pub mod element_data;
 pub mod text_data;
-pub mod comment_data;

--- a/src/html5_parser/node_data/comment_data.rs
+++ b/src/html5_parser/node_data/comment_data.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, PartialEq, Clone)]
+pub struct CommentData {
+    value: String,
+}
+
+impl Default for CommentData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommentData {
+    pub fn new() -> Self {
+        CommentData {
+            value: "".to_string(),
+        }
+    }
+}

--- a/src/html5_parser/node_data/comment_data.rs
+++ b/src/html5_parser/node_data/comment_data.rs
@@ -15,4 +15,19 @@ impl CommentData {
             value: "".to_string(),
         }
     }
+
+    pub fn new_with_value(value: &str) -> Self {
+        let mut comment_data = CommentData::new();
+        comment_data.set_value(value);
+
+        comment_data
+    }
+
+    pub fn get_value(&self) -> String {
+        self.value.clone()
+    }
+
+    pub fn set_value(&mut self, new_value: &str) {
+        self.value = new_value.to_owned();
+    }
 }

--- a/src/html5_parser/node_data/comment_data.rs
+++ b/src/html5_parser/node_data/comment_data.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, PartialEq, Clone)]
 pub struct CommentData {
-    value: String,
+    pub(crate) value: String,
 }
 
 impl Default for CommentData {
@@ -10,24 +10,19 @@ impl Default for CommentData {
 }
 
 impl CommentData {
-    pub fn new() -> Self {
-        CommentData {
+    pub(crate) fn new() -> Self {
+        Self {
             value: "".to_string(),
         }
     }
 
-    pub fn new_with_value(value: &str) -> Self {
-        let mut comment_data = CommentData::new();
-        comment_data.set_value(value);
-
-        comment_data
+    pub(crate) fn with_value(value: &str) -> Self {
+        Self {
+            value: value.to_string(),
+        }
     }
 
-    pub fn get_value(&self) -> String {
-        self.value.clone()
-    }
-
-    pub fn set_value(&mut self, new_value: &str) {
-        self.value = new_value.to_owned();
+    pub fn value(&self) -> &str {
+        &self.value
     }
 }

--- a/src/html5_parser/node_data/document_data.rs
+++ b/src/html5_parser/node_data/document_data.rs
@@ -1,0 +1,14 @@
+#[derive(Debug, PartialEq, Clone)]
+pub struct DocumentData {}
+
+impl Default for DocumentData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DocumentData {
+    pub fn new() -> Self {
+        DocumentData {}
+    }
+}

--- a/src/html5_parser/node_data/document_data.rs
+++ b/src/html5_parser/node_data/document_data.rs
@@ -8,7 +8,7 @@ impl Default for DocumentData {
 }
 
 impl DocumentData {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         DocumentData {}
     }
 }

--- a/src/html5_parser/node_data/element_data.rs
+++ b/src/html5_parser/node_data/element_data.rs
@@ -2,8 +2,8 @@ use std::collections::hash_map::Iter;
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct ElementAttributes {
-    attributes: HashMap<String, String>,
+pub(crate) struct ElementAttributes {
+    pub(crate) attributes: HashMap<String, String>,
 }
 
 impl Default for ElementAttributes {
@@ -17,49 +17,51 @@ impl Default for ElementAttributes {
 /// This "controls" what you're allowed to do with an element's attributes
 /// so there are no unexpected modifications.
 impl ElementAttributes {
-    pub fn new() -> Self {
-        ElementAttributes {
+    pub(crate) fn new() -> Self {
+        Self {
             attributes: HashMap::new(),
         }
     }
 
-    pub fn contains(&self, name: &str) -> bool {
+    pub(crate) fn with_attributes(attributes: HashMap<String, String>) -> Self {
+        Self {
+            attributes: attributes.clone(),
+        }
+    }
+
+    pub(crate) fn contains(&self, name: &str) -> bool {
         self.attributes.contains_key(name)
     }
 
-    pub fn insert(&mut self, name: &str, value: &str) {
+    pub(crate) fn insert(&mut self, name: &str, value: &str) {
         self.attributes.insert(name.to_owned(), value.to_owned());
     }
 
-    pub fn remove(&mut self, name: &str) {
+    pub(crate) fn remove(&mut self, name: &str) {
         self.attributes.remove(name);
     }
 
-    pub fn get(&self, name: &str) -> Option<&String> {
+    pub(crate) fn get(&self, name: &str) -> Option<&String> {
         self.attributes.get(name)
     }
 
-    pub fn get_mut(&mut self, name: &str) -> Option<&mut String> {
+    pub(crate) fn get_mut(&mut self, name: &str) -> Option<&mut String> {
         self.attributes.get_mut(name)
     }
 
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         self.attributes.clear();
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.attributes.is_empty()
     }
 
-    pub fn iter(&self) -> Iter<'_, String, String> {
+    pub(crate) fn iter(&self) -> Iter<'_, String, String> {
         self.attributes.iter()
     }
 
-    pub fn clone_attributes(&self) -> HashMap<String, String> {
-        self.attributes.clone()
-    }
-
-    pub fn copy_from(&mut self, attribute_map: HashMap<String, String>) {
+    pub(crate) fn copy_from(&mut self, attribute_map: HashMap<String, String>) {
         for (key, value) in attribute_map.iter() {
             self.insert(key, value);
         }
@@ -68,8 +70,8 @@ impl ElementAttributes {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ElementData {
-    name: String,
-    pub attributes: ElementAttributes,
+    pub(crate) name: String,
+    pub(crate) attributes: ElementAttributes,
 }
 
 impl Default for ElementData {
@@ -79,26 +81,24 @@ impl Default for ElementData {
 }
 
 impl ElementData {
-    pub fn new() -> Self {
-        ElementData {
+    pub(crate) fn new() -> Self {
+        Self {
             name: "".to_string(),
             attributes: ElementAttributes::new(),
         }
     }
 
-    pub fn new_with_name_and_attributes(name: &str, attributes: HashMap<String, String>) -> Self {
-        let mut element_data = ElementData::new();
-        element_data.set_name(name);
-        element_data.attributes.copy_from(attributes);
-
-        element_data
+    pub(crate) fn with_name_and_attributes(
+        name: &str,
+        attributes: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            attributes: ElementAttributes::with_attributes(attributes),
+        }
     }
 
-    pub fn get_name(&self) -> String {
-        self.name.clone()
-    }
-
-    pub fn set_name(&mut self, new_name: &str) {
-        self.name = new_name.to_owned();
+    pub fn name(&self) -> &str {
+        &self.name
     }
 }

--- a/src/html5_parser/node_data/element_data.rs
+++ b/src/html5_parser/node_data/element_data.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::collections::hash_map::Iter;
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ElementAttributes {
@@ -55,7 +55,7 @@ impl ElementAttributes {
         self.attributes.iter()
     }
 
-    pub fn clone(&self) -> HashMap<String, String> {
+    pub fn clone_attributes(&self) -> HashMap<String, String> {
         self.attributes.clone()
     }
 

--- a/src/html5_parser/node_data/element_data.rs
+++ b/src/html5_parser/node_data/element_data.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Clone)]
+struct ElementAttributes {
+    attributes: HashMap<String, String>,
+}
+
+impl Default for ElementAttributes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ElementAttributes {
+    pub fn new() -> Self {
+        ElementAttributes {
+            attributes: HashMap::new(),
+        }
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.attributes.contains_key(name)
+    }
+
+    pub fn insert(&mut self, name: &str, value: &str) {
+        self.attributes.insert(name.to_owned(), value.to_owned());
+    }
+
+    pub fn remove(&mut self, name: &str) {
+        self.attributes.remove(name);
+    }
+
+    pub fn get(&self, name: &str) -> Option<&String> {
+        self.attributes.get(name)
+    }
+
+    pub fn get_mut(&mut self, name: &str) -> Option<&mut String> {
+        self.attributes.get_mut(name)
+    }
+
+    pub fn clear(&mut self) {
+        self.attributes.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.attributes.is_empty()
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ElementData {
+    name: String,
+    pub attributes: ElementAttributes,
+}
+
+impl Default for ElementData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ElementData {
+    pub fn new() -> Self {
+        ElementData {
+            name: "".to_string(),
+            attributes: ElementAttributes::new(),
+        }
+    }
+}

--- a/src/html5_parser/node_data/element_data.rs
+++ b/src/html5_parser/node_data/element_data.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
+use std::collections::hash_map::Iter;
 
 #[derive(Debug, PartialEq, Clone)]
-struct ElementAttributes {
+pub struct ElementAttributes {
     attributes: HashMap<String, String>,
 }
 
@@ -11,6 +12,10 @@ impl Default for ElementAttributes {
     }
 }
 
+/// This is a very thin wrapper around a HashMap.
+/// Most of the methods are the same besides contains/insert.
+/// This "controls" what you're allowed to do with an element's attributes
+/// so there are no unexpected modifications.
 impl ElementAttributes {
     pub fn new() -> Self {
         ElementAttributes {
@@ -45,6 +50,20 @@ impl ElementAttributes {
     pub fn is_empty(&self) -> bool {
         self.attributes.is_empty()
     }
+
+    pub fn iter(&self) -> Iter<'_, String, String> {
+        self.attributes.iter()
+    }
+
+    pub fn clone(&self) -> HashMap<String, String> {
+        self.attributes.clone()
+    }
+
+    pub fn copy_from(&mut self, attribute_map: HashMap<String, String>) {
+        for (key, value) in attribute_map.iter() {
+            self.insert(key, value);
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -65,5 +84,21 @@ impl ElementData {
             name: "".to_string(),
             attributes: ElementAttributes::new(),
         }
+    }
+
+    pub fn new_with_name_and_attributes(name: &str, attributes: HashMap<String, String>) -> Self {
+        let mut element_data = ElementData::new();
+        element_data.set_name(name);
+        element_data.attributes.copy_from(attributes);
+
+        element_data
+    }
+
+    pub fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn set_name(&mut self, new_name: &str) {
+        self.name = new_name.to_owned();
     }
 }

--- a/src/html5_parser/node_data/text_data.rs
+++ b/src/html5_parser/node_data/text_data.rs
@@ -15,4 +15,23 @@ impl TextData {
             value: "".to_string(),
         }
     }
+
+    pub fn new_with_value(value: &str) -> Self {
+        let mut text_data = TextData::new();
+        text_data.set_value(value);
+
+        text_data
+    }
+
+    pub fn get_value(&self) -> String {
+        self.value.clone()
+    }
+
+    pub fn set_value(&mut self, new_value: &str) {
+        self.value = new_value.to_owned();
+    }
+
+    pub fn push_str(&mut self, content: &str) {
+        self.value.push_str(content);
+    }
 }

--- a/src/html5_parser/node_data/text_data.rs
+++ b/src/html5_parser/node_data/text_data.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, PartialEq, Clone)]
+pub struct TextData {
+    value: String,
+}
+
+impl Default for TextData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TextData {
+    pub fn new() -> Self {
+        TextData {
+            value: "".to_string(),
+        }
+    }
+}

--- a/src/html5_parser/node_data/text_data.rs
+++ b/src/html5_parser/node_data/text_data.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, PartialEq, Clone)]
 pub struct TextData {
-    value: String,
+    pub(crate) value: String,
 }
 
 impl Default for TextData {
@@ -10,28 +10,19 @@ impl Default for TextData {
 }
 
 impl TextData {
-    pub fn new() -> Self {
-        TextData {
+    pub(crate) fn new() -> Self {
+        Self {
             value: "".to_string(),
         }
     }
 
-    pub fn new_with_value(value: &str) -> Self {
-        let mut text_data = TextData::new();
-        text_data.set_value(value);
-
-        text_data
+    pub(crate) fn with_value(value: &str) -> Self {
+        Self {
+            value: value.to_string(),
+        }
     }
 
-    pub fn get_value(&self) -> String {
-        self.value.clone()
-    }
-
-    pub fn set_value(&mut self, new_value: &str) {
-        self.value = new_value.to_owned();
-    }
-
-    pub fn push_str(&mut self, content: &str) {
-        self.value.push_str(content);
+    pub fn value(&self) -> &str {
+        &self.value
     }
 }

--- a/src/html5_parser/nodes.rs
+++ b/src/html5_parser/nodes.rs
@@ -1,0 +1,4 @@
+pub mod document_data;
+pub mod element_data;
+pub mod text_data;
+pub mod comment_data;

--- a/src/html5_parser/parser.rs
+++ b/src/html5_parser/parser.rs
@@ -9,6 +9,7 @@ use crate::html5_parser::element_class::ElementClass;
 use crate::html5_parser::error_logger::{ErrorLogger, ParseError, ParserError};
 use crate::html5_parser::input_stream::InputStream;
 use crate::html5_parser::node::{Node, NodeData, HTML_NAMESPACE, MATHML_NAMESPACE, SVG_NAMESPACE};
+use crate::html5_parser::node_data::text_data::TextData;
 use crate::html5_parser::parser::adoption_agency::AdoptionResult;
 use crate::html5_parser::parser::attr_replacements::{
     MATHML_ADJUSTMENTS, SVG_ADJUSTMENTS, XML_ADJUSTMENTS,
@@ -3418,8 +3419,8 @@ impl<'a> Html5Parser<'a> {
                 .document
                 .get_node_by_id_mut(*last_child_id)
                 .expect("node not found");
-            if let NodeData::Text(text) = &mut last_child.data {
-                text.push_str(&token.to_string().clone());
+            if let NodeData::Text(TextData { value, .. }) = &mut last_child.data {
+                value.push_str(&token.to_string().clone());
                 return;
             }
         }

--- a/src/html5_parser/parser.rs
+++ b/src/html5_parser/parser.rs
@@ -3418,7 +3418,7 @@ impl<'a> Html5Parser<'a> {
                 .document
                 .get_node_by_id_mut(*last_child_id)
                 .expect("node not found");
-            if let NodeData::Text(text)  = &mut last_child.data {
+            if let NodeData::Text(text) = &mut last_child.data {
                 text.push_str(&token.to_string().clone());
                 return;
             }

--- a/src/html5_parser/parser.rs
+++ b/src/html5_parser/parser.rs
@@ -1991,14 +1991,10 @@ impl<'a> Html5Parser<'a> {
                 }
 
                 // Add attributes to html element
-                if let NodeData::Element {
-                    attributes: node_attributes,
-                    ..
-                } = &mut current_node_mut!(self).data
-                {
+                if let NodeData::Element(element) = &mut current_node_mut!(self).data {
                     for (key, value) in attributes {
-                        if !node_attributes.contains_key(key) {
-                            node_attributes.insert(key.clone(), value.clone());
+                        if !element.attributes.contains(key) {
+                            element.attributes.insert(key, value);
                         }
                     }
                 };
@@ -3326,9 +3322,9 @@ impl<'a> Html5Parser<'a> {
         // e.g., <div class="one two three">
         // NOTE: it seems in base rust, you can't really combine "if" and "if let" so I
         // had to introduce more nesting... please suggest cleaner alternatives if any!
-        if let Ok(contains_class) = node.contains_attribute("class") {
-            if contains_class {
-                if let Some(class_string) = node.get_attribute("class") {
+        if let NodeData::Element(element) = &node.data {
+            if element.attributes.contains("class") {
+                if let Some(class_string) = element.attributes.get("class") {
                     node.classes = Some(ElementClass::from_string(class_string));
                 }
             }
@@ -3422,8 +3418,8 @@ impl<'a> Html5Parser<'a> {
                 .document
                 .get_node_by_id_mut(*last_child_id)
                 .expect("node not found");
-            if let NodeData::Text { ref mut value } = &mut last_child.data {
-                value.push_str(&token.to_string().clone());
+            if let NodeData::Text(text)  = &mut last_child.data {
+                text.push_str(&token.to_string().clone());
                 return;
             }
         }

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -179,7 +179,7 @@ impl<'a> Html5Parser<'a> {
                 // Step 4.13.6
                 // replace the old node with the new replacement node
                 let node_attributes = match node.data {
-                    NodeData::Element(element)  => element.attributes.clone(),
+                    NodeData::Element(element) => element.attributes.clone_attributes(),
                     _ => HashMap::new(),
                 };
 
@@ -220,13 +220,11 @@ impl<'a> Html5Parser<'a> {
 
             // Step 4.15
             let new_element = match formatting_element_node.data {
-                NodeData::Element(element) =>{
-                    Node::new_element(
-                        element.get_name().as_str(), 
-                        element.attributes.clone(), 
-                        HTML_NAMESPACE
-                    )
-                }
+                NodeData::Element(element) => Node::new_element(
+                    element.get_name().as_str(),
+                    element.attributes.clone_attributes(),
+                    HTML_NAMESPACE,
+                ),
                 _ => panic!("formatting element is not an element"),
             };
 

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -179,7 +179,7 @@ impl<'a> Html5Parser<'a> {
                 // Step 4.13.6
                 // replace the old node with the new replacement node
                 let node_attributes = match node.data {
-                    NodeData::Element { ref attributes, .. } => attributes.clone(),
+                    NodeData::Element(element)  => element.attributes.clone(),
                     _ => HashMap::new(),
                 };
 
@@ -220,11 +220,13 @@ impl<'a> Html5Parser<'a> {
 
             // Step 4.15
             let new_element = match formatting_element_node.data {
-                NodeData::Element {
-                    ref name,
-                    ref attributes,
-                    ..
-                } => Node::new_element(name.as_str(), attributes.clone(), HTML_NAMESPACE),
+                NodeData::Element(element) =>{
+                    Node::new_element(
+                        element.get_name().as_str(), 
+                        element.attributes.clone(), 
+                        HTML_NAMESPACE
+                    )
+                }
                 _ => panic!("formatting element is not an element"),
             };
 
@@ -301,8 +303,8 @@ impl<'a> Html5Parser<'a> {
                         .get_node_by_id(node_id)
                         .expect("node not found")
                         .clone();
-                    if let NodeData::Element { ref name, .. } = node.data {
-                        if name == subject {
+                    if let NodeData::Element(element) = node.data {
+                        if element.get_name() == subject {
                             return Some(idx);
                         }
                     }

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -1,4 +1,5 @@
 use crate::html5_parser::node::{Node, NodeData, NodeId, HTML_NAMESPACE};
+use crate::html5_parser::node_data::element_data::ElementData;
 use crate::html5_parser::parser::{ActiveElement, Html5Parser, Scope};
 use crate::html5_parser::tokenizer::token::Token;
 use std::collections::HashMap;
@@ -179,7 +180,9 @@ impl<'a> Html5Parser<'a> {
                 // Step 4.13.6
                 // replace the old node with the new replacement node
                 let node_attributes = match node.data {
-                    NodeData::Element(element) => element.attributes.clone_attributes(),
+                    NodeData::Element(ElementData { attributes, .. }) => {
+                        attributes.attributes.clone()
+                    }
                     _ => HashMap::new(),
                 };
 
@@ -220,11 +223,11 @@ impl<'a> Html5Parser<'a> {
 
             // Step 4.15
             let new_element = match formatting_element_node.data {
-                NodeData::Element(element) => Node::new_element(
-                    element.get_name().as_str(),
-                    element.attributes.clone_attributes(),
-                    HTML_NAMESPACE,
-                ),
+                NodeData::Element(ElementData {
+                    name, attributes, ..
+                }) => {
+                    Node::new_element(name.as_str(), attributes.attributes.clone(), HTML_NAMESPACE)
+                }
                 _ => panic!("formatting element is not an element"),
             };
 
@@ -301,8 +304,8 @@ impl<'a> Html5Parser<'a> {
                         .get_node_by_id(node_id)
                         .expect("node not found")
                         .clone();
-                    if let NodeData::Element(element) = node.data {
-                        if element.get_name() == subject {
+                    if let NodeData::Element(ElementData { name, .. }) = node.data {
+                        if name == subject {
                             return Some(idx);
                         }
                     }

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -367,14 +367,14 @@ mod tests {
             NodeData::Element(element) => {
                 element.attributes.insert("id", "myid");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         match &mut node2.data {
             NodeData::Element(element) => {
                 element.attributes.insert("id", "myid");
             }
-            _ => assert!(false),
+            _ => panic!(),
         }
 
         let mut doc = Document::new();

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -123,8 +123,10 @@ impl Document {
     // Add to the document
     pub fn add_node(&mut self, node: Node, parent_id: NodeId) -> NodeId {
         let mut node_named_id: Option<String> = None;
-        if let Some(named_id) = node.get_attribute("id") {
-            node_named_id = Some(named_id.clone());
+        if let NodeData::Element(element) = &node.data {
+            if let Some(named_id) = element.attributes.get("id") {
+                node_named_id = Some(named_id.clone());
+            }
         }
 
         let node_type = node.type_of();
@@ -181,18 +183,18 @@ impl Document {
         }
 
         match &node.data {
-            NodeData::Document => {
+            NodeData::Document(_) => {
                 _ = writeln!(f, "{}Document", buffer);
             }
-            NodeData::Text { value } => {
-                _ = writeln!(f, "{}\"{}\"", buffer, value);
+            NodeData::Text(text) => {
+                _ = writeln!(f, "{}\"{}\"", buffer, text.get_value() );
             }
-            NodeData::Comment { value } => {
-                _ = writeln!(f, "{}<!-- {} -->", buffer, value);
+            NodeData::Comment(comment) => {
+                _ = writeln!(f, "{}<!-- {} -->", buffer, comment.get_value() );
             }
-            NodeData::Element { name, attributes } => {
-                _ = write!(f, "{}<{}", buffer, name);
-                for (key, value) in attributes.iter() {
+            NodeData::Element(element) => {
+                _ = write!(f, "{}<{}", buffer, element.get_name());
+                for (key, value) in element.attributes.iter() {
                     _ = write!(f, " {}={}", key, value);
                 }
                 _ = writeln!(f, ">");

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -2,6 +2,9 @@ use crate::html5_parser::node::NodeTrait;
 use crate::html5_parser::node::NodeType;
 use crate::html5_parser::node::{Node, NodeData, NodeId};
 use crate::html5_parser::node_arena::NodeArena;
+use crate::html5_parser::node_data::{
+    comment_data::CommentData, element_data::ElementData, text_data::TextData,
+};
 use crate::html5_parser::parser::quirks::QuirksMode;
 use crate::html5_parser::parser::HashMap;
 use std::fmt;
@@ -186,15 +189,15 @@ impl Document {
             NodeData::Document(_) => {
                 _ = writeln!(f, "{}Document", buffer);
             }
-            NodeData::Text(text) => {
-                _ = writeln!(f, "{}\"{}\"", buffer, text.get_value());
+            NodeData::Text(TextData { value }) => {
+                _ = writeln!(f, "{}\"{}\"", buffer, value);
             }
-            NodeData::Comment(comment) => {
-                _ = writeln!(f, "{}<!-- {} -->", buffer, comment.get_value());
+            NodeData::Comment(CommentData { value }) => {
+                _ = writeln!(f, "{}<!-- {} -->", buffer, value);
             }
-            NodeData::Element(element) => {
-                _ = write!(f, "{}<{}", buffer, element.get_name());
-                for (key, value) in element.attributes.iter() {
+            NodeData::Element(ElementData { name, attributes }) => {
+                _ = write!(f, "{}<{}", buffer, name);
+                for (key, value) in attributes.iter() {
                     _ = write!(f, " {}={}", key, value);
                 }
                 _ = writeln!(f, ">");

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -187,10 +187,10 @@ impl Document {
                 _ = writeln!(f, "{}Document", buffer);
             }
             NodeData::Text(text) => {
-                _ = writeln!(f, "{}\"{}\"", buffer, text.get_value() );
+                _ = writeln!(f, "{}\"{}\"", buffer, text.get_value());
             }
             NodeData::Comment(comment) => {
-                _ = writeln!(f, "{}<!-- {} -->", buffer, comment.get_value() );
+                _ = writeln!(f, "{}<!-- {} -->", buffer, comment.get_value());
             }
             NodeData::Element(element) => {
                 _ = write!(f, "{}<{}", buffer, element.get_name());
@@ -231,7 +231,7 @@ impl fmt::Display for Document {
 #[cfg(test)]
 mod tests {
     use crate::html5_parser::node::HTML_NAMESPACE;
-    use crate::html5_parser::parser::{Document, Node, NodeId};
+    use crate::html5_parser::parser::{Document, Node, NodeData, NodeId};
     use std::collections::HashMap;
 
     #[ignore]
@@ -363,8 +363,19 @@ mod tests {
         let mut node1 = Node::new_element("div", attributes.clone(), HTML_NAMESPACE);
         let mut node2 = Node::new_element("div", attributes.clone(), HTML_NAMESPACE);
 
-        let _ = node1.insert_attribute("id", "myid");
-        let _ = node2.insert_attribute("id", "myid");
+        match &mut node1.data {
+            NodeData::Element(element) => {
+                element.attributes.insert("id", "myid");
+            }
+            _ => assert!(false),
+        }
+
+        match &mut node2.data {
+            NodeData::Element(element) => {
+                element.attributes.insert("id", "myid");
+            }
+            _ => assert!(false),
+        }
 
         let mut doc = Document::new();
         let _ = doc.add_node(node1, NodeId(1));

--- a/src/html5_parser/parser/lib.rs
+++ b/src/html5_parser/parser/lib.rs
@@ -1,0 +1,1 @@
+pub mod nodes;


### PR DESCRIPTION
Following #108, this PR creates dedicated structs to hold the node data. This is to remove some bloat from the `Node` struct itself as well as simplify the methods by avoiding type checks at the top.

Currently these new structs are basic encapsulation over a standard type (such as `String` or `HashMap<String, String>`). I was torn between whether or not to keep this very thin wrapper over the underlying private type or to expose the underlying type as public. The benefit of keeping it private is this allows us to define a very explicit interface of how this data should be used, the downside is "duplicating" method calls since most of these are 1:1 with the underlying type's methods.

When it comes to usage, you can either use `if let` if you want to verify a type before performing an operation:

```rust
let node = document.get_node_by_id(NodeId::from(4));

// ignored if node is not this type
if let NodeData::Text(TextData { value, .. }) = &node.data {
    // do something with "value"
}
```

Or you can use `match` if you want to do some type of error handling:
```rust
let node = document.get_node_by_id(NodeId::from(4));

match &node.data {
    NodeData::Text(TextData { value, .. }) => {
        // do something with "value"
    }
    _ => /* oh no, this is not a text node, do something! */
}
```

I've also ran `parser_test` to make sure this somehow didn't break the parser and verified we are still getting 76 passing tests (the same value as Joshua posted in Slack earlier)

NOTE: we may end up moving both the  `named_id` and `class` members & methods into the new `ElementData` struct if these are not applicable to other nodes, but I let them be for now.

EDIT: forgot to mention, this also removed a few duplicate tests that I felt were redundant. I also removed the `non_element` tests in `Node` since those checks are no longer required with this new API