### PR TITLE
Create doc comments

### DIFF
--- a/src/html5_parser/error_logger.rs
+++ b/src/html5_parser/error_logger.rs
@@ -1,6 +1,6 @@
 use crate::html5_parser::input_stream::Position;
 
-// Possible parser error enumerated
+/// Possible parser error enumerated
 pub enum ParserError {
     AbruptDoctypePublicIdentifier,
     AbruptDoctypeSystemIdentifier,
@@ -57,8 +57,8 @@ pub enum ParserError {
     ExpectedDocTypeButGotEndTag,
 }
 
-// Parser errors as string representation
 impl ParserError {
+    /// Parser errors as string representation
     pub fn as_str(&self) -> &'static str {
         match self {
             ParserError::AbruptDoctypePublicIdentifier => "abrupt-doctype-public-identifier",
@@ -152,22 +152,27 @@ impl ParserError {
     }
 }
 
-// Parser error that defines an error (message) on the given position
+/// Parser error that defines an error (message) on the given position
 #[derive(Debug, PartialEq, Clone)]
 pub struct ParseError {
-    pub message: String, // Parse message
-    pub line: usize,     // Line number of the error
-    pub col: usize,      // Offset on line of the error
-    pub offset: usize,   // Position of the error on the line
+    /// Parse message
+    pub message: String,
+    /// Line number of the error
+    pub line: usize,
+    /// Offset on line of the error
+    pub col: usize,
+    /// Position of the error on the line
+    pub offset: usize,
 }
 
 #[derive(Clone)]
 pub struct ErrorLogger {
-    errors: Vec<ParseError>, // List of errors that occurred during parsing
+    /// List of errors that occurred during parsing
+    errors: Vec<ParseError>,
 }
 
 impl ErrorLogger {
-    // Creates a new error logger
+    /// Creates a new error logger
     pub fn new() -> Self {
         ErrorLogger { errors: Vec::new() }
     }
@@ -180,12 +185,12 @@ impl Default for ErrorLogger {
 }
 
 impl ErrorLogger {
-    // Returns a cloned instance of the errors
+    /// Returns a cloned instance of the errors
     pub fn get_errors(&self) -> Vec<ParseError> {
         self.errors.clone()
     }
 
-    // Adds a new error to the error logger
+    /// Adds a new error to the error logger
     pub fn add_error(&mut self, pos: Position, message: &str) {
         // Check if the error already exists, if so, don't add it again
         for err in &self.errors {

--- a/src/html5_parser/input_stream.rs
+++ b/src/html5_parser/input_stream.rs
@@ -8,11 +8,11 @@ use std::{fmt, io};
 pub enum Encoding {
     /// Stream is of UTF8 characters
     UTF8,
-    // Stream is of 8bit ASCII
+    /// Stream is of 8bit ASCII
     ASCII,
 }
 
-// The confidence decides how confident we are that the input stream is of this encoding
+/// The confidence decides how confident we are that the input stream is of this encoding
 #[derive(PartialEq)]
 pub enum Confidence {
     /// This encoding might be the one we need
@@ -43,11 +43,11 @@ impl fmt::Display for Position {
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum Element {
-    // Standard UTF character
+    /// Standard UTF character
     Utf8(char),
-    // Surrogate character (since they cannot be stored in <char>)
+    /// Surrogate character (since they cannot be stored in <char>)
     Surrogate(u16),
-    // End of stream
+    /// End of stream
     Eof,
 }
 

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -105,8 +105,8 @@ pub struct Node {
 }
 
 impl Node {
-    // This will only compare against the tag, namespace and attributes. Both nodes could still have
-    // other parents and children.
+    /// This will only compare against the tag, namespace and attributes. Both nodes could still have
+    /// other parents and children.
     pub fn matches_tag_and_attrs(&self, other: &Self) -> bool {
         self.name == other.name && self.namespace == other.namespace && self.data == other.data
     }
@@ -246,11 +246,11 @@ impl Node {
 }
 
 pub trait NodeTrait {
-    // Return the token type of the given token
+    /// Return the token type of the given token
     fn type_of(&self) -> NodeType;
 }
 
-// Each node implements the NodeTrait and has a type_of that will return the node type.
+/// Each node implements the NodeTrait and has a type_of that will return the node type.
 impl NodeTrait for Node {
     fn type_of(&self) -> NodeType {
         match self.data {

--- a/src/html5_parser/node/arena.rs
+++ b/src/html5_parser/node/arena.rs
@@ -4,9 +4,12 @@ use std::collections::HashMap;
 use super::NodeId;
 
 pub struct NodeArena {
-    nodes: HashMap<NodeId, Node>, // Current nodes
-    order: Vec<NodeId>,           // Order of nodes
-    next_id: NodeId,              // next id to use
+    /// Current nodes
+    nodes: HashMap<NodeId, Node>,
+    /// Order of nodes
+    order: Vec<NodeId>,
+    /// next id to use
+    next_id: NodeId,
 }
 
 impl NodeArena {

--- a/src/html5_parser/parser.rs
+++ b/src/html5_parser/parser.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::rc::Rc;
 
-// Insertion modes as defined in 13.2.4.1
+/// Insertion modes as defined in 13.2.4.1
 #[derive(Debug, Copy, Clone, PartialEq)]
 enum InsertionMode {
     Initial,
@@ -53,7 +53,7 @@ enum InsertionMode {
     AfterAfterFrameset,
 }
 
-// Additional extensions to the Vec type so we can do some stack operations
+/// Additional extensions to the Vec type so we can do some stack operations
 trait VecExtensions<T> {
     fn pop_until<F>(&mut self, f: F)
     where
@@ -95,7 +95,7 @@ macro_rules! acknowledge_closing_tag {
     };
 }
 
-// Pops the last element from the open elements until we reach $name
+/// Pops the last element from the open elements until we reach $name
 macro_rules! pop_until {
     ($self:expr, $name:expr) => {
         loop {
@@ -112,7 +112,7 @@ macro_rules! pop_until {
     };
 }
 
-// Pops the last element from the open elements until we reach any of the elements in $arr
+/// Pops the last element from the open elements until we reach any of the elements in $arr
 macro_rules! pop_until_any {
     ($self:expr, $arr:expr) => {
         $self.open_elements.pop_until(|node_id| {
@@ -128,7 +128,7 @@ macro_rules! pop_until_any {
     };
 }
 
-// Remove the given node_id from the open elements stack
+/// Remove the given node_id from the open elements stack
 macro_rules! open_elements_remove {
     ($self:expr, $target_node_id: expr) => {
         $self
@@ -137,7 +137,7 @@ macro_rules! open_elements_remove {
     };
 }
 
-// Pops the last element from the open elements, and panics if it is not $name
+/// Pops the last element from the open elements, and panics if it is not $name
 macro_rules! pop_check {
     ($self:expr, $name:expr) => {
         if !$self.open_elements.pop_check(|&node_id| {
@@ -153,7 +153,7 @@ macro_rules! pop_check {
     };
 }
 
-// Checks if the last element on the open elements is $name, and panics if not
+/// Checks if the last element on the open elements is $name, and panics if not
 macro_rules! check_last_element {
     ($self:expr, $name:expr) => {
         let node_id = $self.open_elements.last().unwrap_or_default();
@@ -169,7 +169,7 @@ macro_rules! check_last_element {
     };
 }
 
-// Get the idx element from the open elements stack
+/// Get the idx element from the open elements stack
 macro_rules! open_elements_find_index {
     ($self:expr, $node_id:expr) => {
         $self
@@ -180,7 +180,7 @@ macro_rules! open_elements_find_index {
     };
 }
 
-// Get the idx element from the open elements stack
+/// Get the idx element from the open elements stack
 macro_rules! open_elements_get {
     ($self:expr, $idx:expr) => {
         $self
@@ -190,7 +190,7 @@ macro_rules! open_elements_get {
     };
 }
 
-// Returns true when the open elements has $name
+/// Returns true when the open elements has $name
 macro_rules! open_elements_has {
     ($self:expr, $name:expr) => {
         $self.open_elements.iter().rev().any(|node_id| {
@@ -214,7 +214,7 @@ macro_rules! open_elements_has_id {
     };
 }
 
-// Returns the current node: the last node in the open elements list
+/// Returns the current node: the last node in the open elements list
 macro_rules! current_node {
     ($self:expr) => {{
         let current_node_idx = $self.open_elements.last().unwrap_or_default();
@@ -225,7 +225,7 @@ macro_rules! current_node {
     }};
 }
 
-// Returns the current node as a mutable reference
+/// Returns the current node as a mutable reference
 macro_rules! current_node_mut {
     ($self:expr) => {{
         let current_node_idx = $self.open_elements.last().unwrap_or_default();
@@ -245,7 +245,7 @@ macro_rules! get_node_by_id {
 #[macro_use]
 mod adoption_agency;
 
-// Active formatting elements, which could be a regular node(id), or a marker
+/// Active formatting elements, which could be a regular node(id), or a marker
 #[derive(PartialEq, Clone, Copy)]
 enum ActiveElement {
     Node(NodeId),
@@ -261,31 +261,51 @@ impl ActiveElement {
     }
 }
 
-// The main parser object
+/// The main parser object
 pub struct Html5Parser<'a> {
-    tokenizer: Tokenizer<'a>,                       // tokenizer object
-    insertion_mode: InsertionMode,                  // current insertion mode
-    original_insertion_mode: InsertionMode,         // original insertion mode (used for text mode)
-    template_insertion_mode: Vec<InsertionMode>,    // template insertion mode stack
-    parser_cannot_change_mode: bool,                // ??
-    current_token: Token,                           // Current token from the tokenizer
-    reprocess_token: bool, // If true, the current token should be processed again
-    open_elements: Vec<NodeId>, // Stack of open elements
-    head_element: Option<NodeId>, // Current head element
-    form_element: Option<NodeId>, // Current form element
-    scripting_enabled: bool, // If true, scripting is enabled
-    frameset_ok: bool,     // if true, we can insert a frameset
-    foster_parenting: bool, // Foster parenting flag
-    script_already_started: bool, // If true, the script engine has already started
-    pending_table_character_tokens: String, // Pending table character tokens
-    ack_self_closing: bool, // Acknowledge self closing tags
-    active_formatting_elements: Vec<ActiveElement>, // List of active formatting elements or markers
-    is_fragment_case: bool, // Is the current parsing a fragment case
-    document: Document,    // A reference to the document we are parsing
-    error_logger: Rc<RefCell<ErrorLogger>>, // Error logger, which is shared with the tokenizer
+    /// tokenizer object
+    tokenizer: Tokenizer<'a>,
+    /// current insertion mode
+    insertion_mode: InsertionMode,
+    /// original insertion mode (used for text mode)
+    original_insertion_mode: InsertionMode,
+    /// template insertion mode stack
+    template_insertion_mode: Vec<InsertionMode>,
+    /// ??
+    parser_cannot_change_mode: bool,
+    /// Current token from the tokenizer
+    current_token: Token,
+    /// If true, the current token should be processed again
+    reprocess_token: bool,
+    /// Stack of open elements
+    open_elements: Vec<NodeId>,
+    /// Current head element
+    head_element: Option<NodeId>,
+    /// Current form element
+    form_element: Option<NodeId>,
+    /// If true, scripting is enabled
+    scripting_enabled: bool,
+    /// if true, we can insert a frameset
+    frameset_ok: bool,
+    /// Foster parenting flag
+    foster_parenting: bool,
+    /// If true, the script engine has already started
+    script_already_started: bool,
+    /// Pending table character tokens
+    pending_table_character_tokens: String,
+    /// Acknowledge self closing tags
+    ack_self_closing: bool,
+    /// List of active formatting elements or markers
+    active_formatting_elements: Vec<ActiveElement>,
+    /// Is the current parsing a fragment case
+    is_fragment_case: bool,
+    /// A reference to the document we are parsing
+    document: Document,
+    /// Error logger, which is shared with the tokenizer
+    error_logger: Rc<RefCell<ErrorLogger>>,
 }
 
-// Defines the scopes for in_scope()
+/// Defines the scopes for in_scope()
 enum Scope {
     Regular,
     ListItem,
@@ -295,7 +315,7 @@ enum Scope {
 }
 
 impl<'a> Html5Parser<'a> {
-    // Creates a new parser object with the given input stream
+    /// Creates a new parser object with the given input stream
     pub fn new(stream: &'a mut InputStream) -> Self {
         // Create a new error logger that will be used in both the tokenizer and the parser
         let error_logger = Rc::new(RefCell::new(ErrorLogger::new()));
@@ -326,7 +346,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Parses the input stream into a Node tree
+    /// Parses the input stream into a Node tree
     pub fn parse(&mut self) -> Result<(&mut Document, Vec<ParseError>)> {
         loop {
             // If reprocess_token is true, we should process the same token again
@@ -1667,19 +1687,19 @@ impl<'a> Html5Parser<'a> {
         ))
     }
 
-    // Retrieves a list of all errors generated by the parser/tokenizer
+    /// Retrieves a list of all errors generated by the parser/tokenizer
     pub fn get_parse_errors(&self) -> Vec<ParseError> {
         self.error_logger.borrow().get_errors().clone()
     }
 
-    // Send a parse error to the error logger
+    /// Send a parse error to the error logger
     fn parse_error(&self, message: &str) {
         self.error_logger
             .borrow_mut()
             .add_error(self.tokenizer.get_position(), message);
     }
 
-    // Create a new node that is not connected or attached to the document arena
+    /// Create a new node that is not connected or attached to the document arena
     fn create_node(&self, token: &Token, namespace: &str) -> Node {
         let val: String;
         match token {
@@ -1707,8 +1727,8 @@ impl<'a> Html5Parser<'a> {
 
     fn flush_pending_table_character_tokens(&mut self) {}
 
-    // This function will pop elements off the stack until it reaches the first element that matches
-    // our condition (which can be changed with the except and thoroughly parameters)
+    /// This function will pop elements off the stack until it reaches the first element that matches
+    /// our condition (which can be changed with the except and thoroughly parameters)
     fn generate_all_implied_end_tags(&mut self, except: Option<&str>, thoroughly: bool) {
         loop {
             if self.open_elements.is_empty() {
@@ -1740,7 +1760,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Reset insertion mode based on all kind of rules
+    /// Reset insertion mode based on all kind of rules
     fn reset_insertion_mode(&mut self) {
         let mut last = false;
         let mut idx = self.open_elements.len() - 1;
@@ -1843,7 +1863,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Pop all elements back to a table context
+    /// Pop all elements back to a table context
     fn clear_stack_back_to_table_context(&mut self) {
         while !self.open_elements.is_empty() {
             if ["table", "template", "html"].contains(&current_node!(self).name.as_str()) {
@@ -1853,7 +1873,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Pop all elements back to a table context
+    /// Pop all elements back to a table context
     fn clear_stack_back_to_table_body_context(&mut self) {
         while !self.open_elements.is_empty() {
             if ["tbody", "tfoot", "thead", "template", "html"]
@@ -1865,7 +1885,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Pop all elements back to a table row context
+    /// Pop all elements back to a table row context
     fn clear_stack_back_to_table_row_context(&mut self) {
         while !self.open_elements.is_empty() {
             let val = current_node!(self).name.clone();
@@ -1876,7 +1896,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Checks if the given element is in given scope
+    /// Checks if the given element is in given scope
     fn is_in_scope(&self, tag: &str, scope: Scope) -> bool {
         for &node_id in self.open_elements.iter().rev() {
             let node = self
@@ -1936,7 +1956,7 @@ impl<'a> Html5Parser<'a> {
         false
     }
 
-    // Closes a table cell and switches the insertion mode to InRow
+    /// Closes a table cell and switches the insertion mode to InRow
     fn close_cell(&mut self) {
         self.generate_all_implied_end_tags(None, false);
 
@@ -1951,7 +1971,7 @@ impl<'a> Html5Parser<'a> {
         self.insertion_mode = InsertionMode::InRow;
     }
 
-    // Handle insertion mode "in_body"
+    /// Handle insertion mode "in_body"
     fn handle_in_body(&mut self) {
         let mut any_other_end_tag = false;
 
@@ -2778,7 +2798,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Handle insertion mode "in_head"
+    /// Handle insertion mode "in_head"
     fn handle_in_head(&mut self) {
         let mut anything_else = false;
 
@@ -2887,12 +2907,12 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Handle insertion mode "in_template"
+    /// Handle insertion mode "in_template"
     fn handle_in_template(&mut self) {
         todo!()
     }
 
-    // Handle insertion mode "in_table"
+    /// Handle insertion mode "in_table"
     fn handle_in_table(&mut self) {
         let mut anything_else = false;
 
@@ -3054,12 +3074,12 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Handle insertion mode "in_select"
+    /// Handle insertion mode "in_select"
     fn handle_in_select(&mut self) {
         todo!()
     }
 
-    // Returns true if the given tag if found in the active formatting elements list (until the first marker)
+    /// Returns true if the given tag if found in the active formatting elements list (until the first marker)
     fn active_formatting_elements_has_until_marker(&self, tag: &str) -> Option<NodeId> {
         if self.active_formatting_elements.is_empty() {
             return None;
@@ -3085,12 +3105,12 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Adds a marker to the active formatting stack
+    /// Adds a marker to the active formatting stack
     fn active_formatting_elements_push_marker(&mut self) {
         self.active_formatting_elements.push(ActiveElement::Marker);
     }
 
-    // Clear the active formatting stack until we reach the first marker
+    /// Clear the active formatting stack until we reach the first marker
     fn active_formatting_elements_clear_until_marker(&mut self) {
         while let Some(active_elem) = self.active_formatting_elements.pop() {
             if let ActiveElement::Marker = active_elem {
@@ -3100,7 +3120,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Remove the given node_id from the active formatting elements list
+    /// Remove the given node_id from the active formatting elements list
     fn active_formatting_elements_remove(&mut self, target_node_id: NodeId) {
         self.active_formatting_elements
             .retain(|node_id| match node_id {
@@ -3109,7 +3129,7 @@ impl<'a> Html5Parser<'a> {
             });
     }
 
-    // Push a node onto the active formatting stack, make sure only max 3 of them can be added (between markers)
+    /// Push a node onto the active formatting stack, make sure only max 3 of them can be added (between markers)
     fn active_formatting_elements_push(&mut self, node_id: NodeId) {
         let mut idx = self.active_formatting_elements.len();
         if idx == 0 {
@@ -3249,7 +3269,7 @@ impl<'a> Html5Parser<'a> {
         todo!()
     }
 
-    // Close the p element that may or may not be on the open elements stack
+    /// Close the p element that may or may not be on the open elements stack
     fn close_p_element(&mut self) {
         self.generate_all_implied_end_tags(Some("p"), false);
 
@@ -3261,7 +3281,7 @@ impl<'a> Html5Parser<'a> {
         self.open_elements.pop(); // Pop the p element itself
     }
 
-    // Adjusts attributes names in the given token for SVG
+    /// Adjusts attributes names in the given token for SVG
     fn adjust_svg_attributes(&self, token: &mut Token) {
         if let Token::StartTagToken { attributes, .. } = token {
             let mut new_attributes = HashMap::new();
@@ -3348,7 +3368,7 @@ impl<'a> Html5Parser<'a> {
         node_id
     }
 
-    // Switch the parser and tokenizer to the RAWTEXT state
+    /// Switch the parser and tokenizer to the RAWTEXT state
     fn parse_raw_data(&mut self) {
         self.insert_html_element(&self.current_token.clone());
 
@@ -3358,7 +3378,7 @@ impl<'a> Html5Parser<'a> {
         self.insertion_mode = InsertionMode::Text;
     }
 
-    // Switch the parser and tokenizer to the RCDATA state
+    /// Switch the parser and tokenizer to the RCDATA state
     fn parse_rcdata(&mut self) {
         self.insert_html_element(&self.current_token.clone());
 

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -14,7 +14,7 @@ pub enum AdoptionResult {
 
 impl<'a> Html5Parser<'a> {
     /// When we talk about nodes, there are 3 contexts to consider:
-    /// 
+    ///
     /// - The actual node data. This is called "node" in the code.
     /// - The node id. This is called "node_id" in the code.
     /// - The node index. This is called "node_idx" in the code. This is the index of the node in  

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -13,14 +13,12 @@ pub enum AdoptionResult {
 }
 
 impl<'a> Html5Parser<'a> {
-    /**
-     * When we talk about nodes, there are 3 contexts to consider:
-     *
-     * - The actual node data. This is called "node" in the code.
-     * - The node id. This is called "node_id" in the code.
-     * - The node index. This is called "node_idx" in the code. This is the index of the node in
-     *   either the open_elements or active_formatting_elements stack.
-     */
+    /// When we talk about nodes, there are 3 contexts to consider:
+    /// 
+    /// - The actual node data. This is called "node" in the code.
+    /// - The node id. This is called "node_id" in the code.
+    /// - The node index. This is called "node_idx" in the code. This is the index of the node in  
+    /// either the open_elements or active_formatting_elements stack.
     pub fn run_adoption_agency(&mut self, token: &Token) -> AdoptionResult {
         // Step 1
         let subject = match token {
@@ -260,7 +258,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    // Find the furthest block element in the stack of open elements that is above the formatting element
+    /// Find the furthest block element in the stack of open elements that is above the formatting element
     fn find_furthest_block_idx(&self, formatting_element_id: NodeId) -> Option<usize> {
         // Find the index of the wanted formatting element id
         let element_idx_oe = self
@@ -285,7 +283,7 @@ impl<'a> Html5Parser<'a> {
         None
     }
 
-    // Find the formatting element with the given subject between the end of the list and the first marker (or start when there is no marker)
+    /// Find the formatting element with the given subject between the end of the list and the first marker (or start when there is no marker)
     fn find_formatting_element(&self, subject: &str) -> Option<usize> {
         if self.active_formatting_elements.is_empty() {
             return None;

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -38,7 +38,7 @@ impl Default for Document {
 }
 
 impl Document {
-    // Creates a new document
+    /// Creates a new document
     pub fn new() -> Self {
         let mut arena = NodeArena::new();
         arena.add_node(Node::new_document());
@@ -72,8 +72,8 @@ impl Document {
         self.arena.get_node_mut(*node_id)
     }
 
-    // according to HTML5 spec: 3.2.3.1
-    // https://www.w3.org/TR/2011/WD-html5-20110405/elements.html#the-id-attribute
+    /// according to HTML5 spec: 3.2.3.1
+    /// https://www.w3.org/TR/2011/WD-html5-20110405/elements.html#the-id-attribute
     fn validate_named_id(&self, named_id: &str) -> bool {
         if named_id.contains(char::is_whitespace) {
             return false;
@@ -121,7 +121,7 @@ impl Document {
         }
     }
 
-    // Add to the document
+    /// Add to the document
     pub fn add_node(&mut self, node: Node, parent_id: NodeId) -> NodeId {
         let mut node_named_id: Option<String> = None;
         if let NodeData::Element(element) = &node.data {
@@ -165,7 +165,7 @@ impl Document {
         self.arena.get_node_mut(node_id).unwrap().parent = Some(parent_id);
     }
 
-    // return the root node
+    /// return the root node
     pub fn get_root(&self) -> &Node {
         self.arena
             .get_node(NodeId::root())

--- a/src/html5_parser/parser/quirks.rs
+++ b/src/html5_parser/parser/quirks.rs
@@ -8,7 +8,7 @@ pub enum QuirksMode {
 }
 
 impl<'a> Html5Parser<'a> {
-    // returns the correct quirk mode for the given doctype
+    /// returns the correct quirk mode for the given doctype
     pub(crate) fn identify_quirks_mode(
         &self,
         name: &Option<String>,

--- a/src/html5_parser/tokenizer/character_reference.rs
+++ b/src/html5_parser/tokenizer/character_reference.rs
@@ -8,7 +8,7 @@ use crate::html5_parser::tokenizer::replacement_tables::{TOKEN_NAMED_CHARS, TOKE
 use crate::html5_parser::tokenizer::{Tokenizer, CHAR_REPLACEMENT};
 use lazy_static::lazy_static;
 
-// Different states for the character references
+/// Different states for the character references
 pub enum CcrState {
     CharacterReference,
     NamedCharacterReference,
@@ -33,10 +33,10 @@ macro_rules! consume_temp_buffer {
 }
 
 impl<'a> Tokenizer<'a> {
-    // Consumes a character reference and places this in the tokenizer consume buffer
-    // ref: 8.2.4.69 Tokenizing character references
-
-    // @TODO: fix additional allowed char
+    /// Consumes a character reference and places this in the tokenizer consume buffer
+    /// ref: 8.2.4.69 Tokenizing character references
+    ///
+    /// @TODO: fix additional allowed char
     pub fn consume_character_reference(
         &mut self,
         _additional_allowed_char: Option<Element>,
@@ -333,8 +333,8 @@ impl<'a> Tokenizer<'a> {
         (0x0001..=0x001F).contains(&num) || (0x007F..=0x009F).contains(&num)
     }
 
-    // Finds the longest entity from the current position in the stream. Returns the entity
-    // replacement OR None when no entity has been found.
+    /// Finds the longest entity from the current position in the stream. Returns the entity
+    /// replacement OR None when no entity has been found.
     fn find_entity(&mut self) -> Option<String> {
         let s = self.stream.look_ahead_slice(*LONGEST_ENTITY_LENGTH);
         for i in (0..=s.len()).rev() {

--- a/src/html5_parser/tokenizer/state.rs
+++ b/src/html5_parser/tokenizer/state.rs
@@ -1,4 +1,4 @@
-// These are the states in which the tokenizer can be in.
+/// These are the states in which the tokenizer can be in.
 #[derive(Debug, Copy, Clone)]
 pub enum State {
     DataState,

--- a/src/html5_parser/tokenizer/token.rs
+++ b/src/html5_parser/tokenizer/token.rs
@@ -1,7 +1,7 @@
 use crate::html5_parser::tokenizer::CHAR_NUL;
 use std::collections::HashMap;
 
-// The different tokens types that can be emitted by the tokenizer
+/// The different tokens types that can be emitted by the tokenizer
 #[derive(Debug, PartialEq)]
 pub enum TokenType {
     DocTypeToken,
@@ -18,7 +18,7 @@ pub struct Attribute {
     pub value: String,
 }
 
-// The different token structures that can be emitted by the tokenizer
+/// The different token structures that can be emitted by the tokenizer
 #[derive(Clone, PartialEq)]
 pub enum Token {
     DocTypeToken {
@@ -47,7 +47,7 @@ pub enum Token {
 }
 
 impl Token {
-    // Returns true when any of the characters in the token are null
+    /// Returns true when any of the characters in the token are null
     pub fn is_null(&self) -> bool {
         if let Token::TextToken { value } = self {
             value.chars().any(|ch| ch == CHAR_NUL)
@@ -56,12 +56,12 @@ impl Token {
         }
     }
 
-    // Returns true when the token is an EOF token
+    /// Returns true when the token is an EOF token
     pub fn is_eof(&self) -> bool {
         matches!(self, Token::EofToken)
     }
 
-    // Returns true if the text token is empty or only contains whitespace
+    /// Returns true if the text token is empty or only contains whitespace
     pub fn is_empty_or_white(&self) -> bool {
         if let Token::TextToken { value } = self {
             value.trim().is_empty()
@@ -119,7 +119,7 @@ impl std::fmt::Display for Token {
 }
 
 pub trait TokenTrait {
-    // Return the token type of the given token
+    /// Return the token type of the given token
     fn type_of(&self) -> TokenType;
 }
 

--- a/src/testing/tokenizer.rs
+++ b/src/testing/tokenizer.rs
@@ -137,8 +137,8 @@ impl Test {
         }
     }
 
-    // Run through the parsing without making assertions, for use in benchmarking and in order to
-    // disclose any panics that might happen
+    /// Run through the parsing without making assertions, for use in benchmarking and in order to
+    /// disclose any panics that might happen
     pub fn tokenize(&self) {
         for mut builder in self.builders() {
             let mut tokenizer = builder.build();
@@ -306,7 +306,7 @@ impl Test {
         assert_eq!(name, output, "incorrect end tag");
     }
 
-    // Check if a given doctype matches the expected result
+    /// Check if a given doctype matches the expected result
     fn assert_doctype(
         &self,
         expected: &[Value],


### PR DESCRIPTION
There were still a few files where normal comments (`//`) instead of doc comments (`///`) were used. I replaced (hopefully all of) them with doc comments where ever it was suitable.
Otherwise nothing should have changed.