### PR TITLE
replace macros with functions + remove unnecessary clones

### DIFF
--- a/src/html5_parser/parser.rs
+++ b/src/html5_parser/parser.rs
@@ -1596,7 +1596,7 @@ impl<'a> Html5Parser<'a> {
             .name
             != name
         {
-            panic!("$name tag should be last element in open elements");
+            panic!("{name} tag should be last element in open elements");
         }
     }
 
@@ -1702,7 +1702,7 @@ impl<'a> Html5Parser<'a> {
                 return;
             }
 
-            let val = self.current_node().name.clone();
+            let val = self.current_node().name.as_str();
 
             if let Some(except) = except {
                 if except == val {
@@ -1710,15 +1710,14 @@ impl<'a> Html5Parser<'a> {
                 }
             }
 
-            if thoroughly && !["tbody", "td", "tfoot", "th", "thead", "tr"].contains(&val.as_str())
-            {
+            if thoroughly && !["tbody", "td", "tfoot", "th", "thead", "tr"].contains(&val) {
                 return;
             }
 
             if ![
                 "dd", "dt", "li", "option", "optgroup", "p", "rb", "rp", "rt", "rtc",
             ]
-            .contains(&val.as_str())
+            .contains(&val)
             {
                 return;
             }
@@ -1855,8 +1854,8 @@ impl<'a> Html5Parser<'a> {
     /// Pop all elements back to a table row context
     fn clear_stack_back_to_table_row_context(&mut self) {
         while !self.open_elements.is_empty() {
-            let val = self.current_node().name.clone();
-            if ["tr", "template", "html"].contains(&val.as_str()) {
+            let val = self.current_node().name.as_str();
+            if ["tr", "template", "html"].contains(&val) {
                 return;
             }
             self.open_elements.pop();
@@ -1927,7 +1926,7 @@ impl<'a> Html5Parser<'a> {
     fn close_cell(&mut self) {
         self.generate_all_implied_end_tags(None, false);
 
-        let tag = self.current_node().name.clone();
+        let tag = self.current_node().name.as_str();
         if tag != "td" && tag != "th" {
             self.parse_error("current node should be td or th");
         }
@@ -3408,7 +3407,7 @@ impl<'a> Html5Parser<'a> {
                 .get_node_by_id_mut(*last_child_id)
                 .expect("node not found");
             if let NodeData::Text(TextData { value, .. }) = &mut last_child.data {
-                value.push_str(&token.to_string().clone());
+                value.push_str(&token.to_string());
                 return;
             }
         }

--- a/src/html5_parser/tokenizer/character_reference.rs
+++ b/src/html5_parser/tokenizer/character_reference.rs
@@ -1,6 +1,6 @@
 use crate::html5_parser::error_logger::ParserError;
 use crate::html5_parser::input_stream::Element;
-use crate::read_char;
+// use crate::read_char;
 
 extern crate lazy_static;
 use crate::html5_parser::input_stream::SeekMode::SeekCur;
@@ -51,7 +51,7 @@ impl<'a> Tokenizer<'a> {
                     self.temporary_buffer.clear();
                     self.temporary_buffer.push('&');
 
-                    let c = read_char!(self);
+                    let c = self.read_char();
                     match c {
                         Element::Utf8(ch) if ch.is_ascii_alphanumeric() => {
                             self.stream.unread();
@@ -113,7 +113,7 @@ impl<'a> Tokenizer<'a> {
                     ccr_state = CcrState::AmbiguousAmpersand;
                 }
                 CcrState::AmbiguousAmpersand => {
-                    let c = read_char!(self);
+                    let c = self.read_char();
                     match c {
                         // Element::Eof => return,
                         Element::Utf8(ch) if ch.is_ascii_alphanumeric() => {
@@ -137,7 +137,7 @@ impl<'a> Tokenizer<'a> {
                 CcrState::NumericCharacterReference => {
                     char_ref_code = Some(0);
 
-                    let c = read_char!(self);
+                    let c = self.read_char();
                     match c {
                         // Element::Eof => ccr_state = CcrState::NumericalCharacterReferenceEndState,
                         Element::Utf8('X') | Element::Utf8('x') => {
@@ -151,7 +151,7 @@ impl<'a> Tokenizer<'a> {
                     }
                 }
                 CcrState::HexadecimalCharacterReferenceStart => {
-                    let c = read_char!(self);
+                    let c = self.read_char();
                     match c {
                         // Element::Eof => ccr_state = CcrState::NumericalCharacterReferenceEndState,
                         Element::Utf8('0'..='9')
@@ -172,7 +172,7 @@ impl<'a> Tokenizer<'a> {
                     }
                 }
                 CcrState::DecimalCharacterReferenceStart => {
-                    let c = read_char!(self);
+                    let c = self.read_char();
                     match c {
                         Element::Utf8('0'..='9') => {
                             self.stream.unread();
@@ -190,7 +190,7 @@ impl<'a> Tokenizer<'a> {
                     }
                 }
                 CcrState::HexadecimalCharacterReference => {
-                    let c = read_char!(self);
+                    let c = self.read_char();
                     match c {
                         // Element::Eof => ccr_state = CcrState::NumericalCharacterReferenceEndState,
                         Element::Utf8('0'..='9') => {
@@ -228,7 +228,7 @@ impl<'a> Tokenizer<'a> {
                     }
                 }
                 CcrState::DecimalCharacterReference => {
-                    let c = read_char!(self);
+                    let c = self.read_char();
                     match c {
                         // Element::Eof => ccr_state = CcrState::NumericalCharacterReferenceEndState,
                         Element::Utf8('0'..='9') => {


### PR DESCRIPTION
I completely missed the macros in the tokenizer. It's mostly the same as in the parser. I left the `to_lowercase` macro as it was because it does not use `self`. `char` has a method called `to_ascii_lowercase` which could be used but it does a check if the char is actually an uppercase ascii letter. The `to_lowercase` macro just assumes this so it should be minimally faster.

I also removed some unnecessary clones in the parser and tokenizer.