### PR TITLE
feat(css): add basic css parser (rdp)

### DIFF
--- a/src/css3_parser.rs
+++ b/src/css3_parser.rs
@@ -1,0 +1,3 @@
+pub mod parser;
+pub mod tokenizer;
+pub mod tokens;

--- a/src/css3_parser.rs
+++ b/src/css3_parser.rs
@@ -1,3 +1,4 @@
+//! This module contains the CSS3 parser
 pub mod parser;
 pub mod tokenizer;
 pub mod tokens;

--- a/src/css3_parser/parser.rs
+++ b/src/css3_parser/parser.rs
@@ -8,6 +8,12 @@ pub struct CSSStyleSheet {
     css_rules: Vec<CSSRule>,
 }
 
+impl Default for CSSStyleSheet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CSSStyleSheet {
     pub fn new() -> CSSStyleSheet {
         CSSStyleSheet {
@@ -28,6 +34,12 @@ pub struct CSSStyleDeclaration {
 #[derive(Debug, PartialEq)]
 pub struct CSSSelector {
     path: Vec<String>,
+}
+
+impl Default for CSSSelector {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CSSSelector {
@@ -85,17 +97,26 @@ pub enum CSSRule {
     CSSMeidaRule(CSSMeidaRule),
 }
 
+/// # CSS3 Parser
+/// The parser using the Recursive Descent Parser algorithm (predictive parser).
+/// The grammer rules is defined using Backus–Naur form (BNF)
 #[derive(Debug, PartialEq)]
-struct CSS3Parser {
+pub struct CSS3Parser {
     tokenizer: CSSTokenizer,
     lookahead: Option<Token>,
     raw: String,
 }
 
+impl Default for CSS3Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CSS3Parser {
     pub fn new() -> CSS3Parser {
         CSS3Parser {
-            tokenizer: CSSTokenizer::new(),
+            tokenizer: CSSTokenizer::default(),
             lookahead: None,
             raw: "".to_string(),
         }
@@ -106,7 +127,7 @@ impl CSS3Parser {
         self.tokenizer.init(raw);
         self.lookahead = self.tokenizer.get_next_token();
 
-        return self.css_style_sheet();
+        self.css_style_sheet()
     }
 
     /// ```txt
@@ -134,7 +155,7 @@ impl CSS3Parser {
             rules.push(self.css_rule());
         }
 
-        return rules;
+        rules
     }
 
     /// ```txt
@@ -196,7 +217,7 @@ impl CSS3Parser {
             }
         }
 
-        return conditions;
+        conditions
     }
 
     /// ```txt
@@ -210,7 +231,7 @@ impl CSS3Parser {
             return MediaCondition::Feature(self.media_feature());
         };
 
-        return MediaCondition::Type(self.media_type());
+        MediaCondition::Type(self.media_type())
     }
 
     /// ```txt
@@ -295,12 +316,12 @@ impl CSS3Parser {
     fn css_style_declaration_list(&mut self) -> Vec<CSSStyleDeclaration> {
         let mut list = Vec::new();
 
-        // todo: add condtion
+        // todo: add condition
         while self.is_next_token(TokenType::Identifier) {
             list.push(self.css_style_declaration());
         }
 
-        return list;
+        list
     }
 
     /// ```txt
@@ -324,7 +345,7 @@ impl CSS3Parser {
     /// ```
     fn prop_name(&mut self) -> String {
         let token = self.consume(TokenType::Identifier);
-        return token.value.to_string();
+        token.value.to_string()
     }
 
     /// ```txt
@@ -334,7 +355,7 @@ impl CSS3Parser {
     /// ```
     fn prop_value(&mut self) -> String {
         let token = self.consume(TokenType::Identifier);
-        return token.value.to_string();
+        token.value.to_string()
     }
 
     fn consume(&mut self, token_type: TokenType) -> Token {
@@ -361,7 +382,7 @@ impl CSS3Parser {
             return token.token_type == token_type;
         }
 
-        return false;
+        false
     }
 
     fn is_next_tokens(&self, token_types: Vec<TokenType>) -> bool {
@@ -370,7 +391,7 @@ impl CSS3Parser {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     fn get_next_token_type(&self) -> Option<TokenType> {
@@ -378,7 +399,7 @@ impl CSS3Parser {
             return Some(token.token_type);
         }
 
-        return None;
+        None
     }
 }
 

--- a/src/css3_parser/parser.rs
+++ b/src/css3_parser/parser.rs
@@ -1,0 +1,479 @@
+use super::{
+    tokenizer::CSSTokenizer,
+    tokens::{Token, TokenType},
+};
+
+#[derive(Debug, PartialEq)]
+pub struct CSSStyleSheet {
+    css_rules: Vec<CSSRule>,
+}
+
+impl CSSStyleSheet {
+    pub fn new() -> CSSStyleSheet {
+        CSSStyleSheet {
+            css_rules: Vec::new(),
+        }
+    }
+}
+
+pub type CSSPropName = String;
+pub type CSSPropValue = String;
+
+#[derive(Debug, PartialEq)]
+pub struct CSSStyleDeclaration {
+    name: CSSPropName,
+    value: CSSPropValue,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CSSSelector {
+    path: Vec<String>,
+}
+
+impl CSSSelector {
+    pub fn new() -> CSSSelector {
+        CSSSelector { path: Vec::new() }
+    }
+
+    pub fn from_str_slice(path: Vec<&str>) -> CSSSelector {
+        CSSSelector {
+            path: path.iter().map(|s| s.to_string()).collect::<Vec<String>>(),
+        }
+    }
+
+    pub fn add(&mut self, value: String) -> &mut CSSSelector {
+        self.path.push(value);
+
+        self
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CSSStyleRule {
+    selector: CSSSelector,
+    style_declarations: Vec<CSSStyleDeclaration>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CSSMeidaRule {
+    conditions: Vec<MediaCondition>,
+    css_rules: Vec<CSSRule>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum MediaType {
+    Screen,
+    Printer,
+    All,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MediaFeature {
+    name: String,
+    value: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum MediaCondition {
+    Type(MediaType),
+    Feature(MediaFeature),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CSSRule {
+    CSSStyleRule(CSSStyleRule),
+    CSSMeidaRule(CSSMeidaRule),
+}
+
+#[derive(Debug, PartialEq)]
+struct CSS3Parser {
+    tokenizer: CSSTokenizer,
+    lookahead: Option<Token>,
+    raw: String,
+}
+
+impl CSS3Parser {
+    pub fn new() -> CSS3Parser {
+        CSS3Parser {
+            tokenizer: CSSTokenizer::new(),
+            lookahead: None,
+            raw: "".to_string(),
+        }
+    }
+
+    pub fn parse(&mut self, raw: &str) -> CSSStyleSheet {
+        self.raw = raw.to_string();
+        self.tokenizer.init(raw);
+        self.lookahead = self.tokenizer.get_next_token();
+
+        return self.css_style_sheet();
+    }
+
+    /// ```txt
+    /// CSSSytleSheet
+    ///     : CSSRulesList
+    ///     ;
+    /// ```
+    fn css_style_sheet(&mut self) -> CSSStyleSheet {
+        CSSStyleSheet {
+            css_rules: self.css_rules_list(),
+        }
+    }
+
+    /// ```txt
+    /// CSSRulesList
+    ///     : CSSRule ....
+    ///     ;
+    /// ```
+    fn css_rules_list(&mut self) -> Vec<CSSRule> {
+        let mut rules: Vec<CSSRule> = Vec::new();
+
+        println!("[css_rules_list]: {:#?}", self.lookahead);
+
+        while !self.is_next_token(TokenType::ClosingBracket) & self.lookahead.is_some() {
+            rules.push(self.css_rule());
+        }
+
+        return rules;
+    }
+
+    /// ```txt
+    /// CSSRule
+    ///     : CSSMediaRule
+    ///     | CSSStyleRule
+    ///     ;
+    /// ```
+    fn css_rule(&mut self) -> CSSRule {
+        if let Some(token) = self.lookahead.clone() {
+            match token.token_type {
+                TokenType::Media => return CSSRule::CSSMeidaRule(self.css_media_rule()),
+                _ => return CSSRule::CSSStyleRule(self.css_style_rule()),
+            }
+        }
+
+        panic!("Unexpected end of input.");
+    }
+
+    /// ```txt
+    /// CSSMediaRule
+    ///     : '@media' MediaCondition '{' CSSRulesList '}'
+    ///     ;
+    /// ```
+    fn css_media_rule(&mut self) -> CSSMeidaRule {
+        self.consume(TokenType::Media);
+        let conditions = self.media_conditions_list();
+        self.consume(TokenType::OpeningBracket);
+        let css_rules = if !self.is_next_token(TokenType::ClosingBracket) {
+            self.css_rules_list()
+        } else {
+            Vec::new()
+        };
+        self.consume(TokenType::ClosingBracket);
+
+        CSSMeidaRule {
+            conditions,
+            css_rules,
+        }
+    }
+
+    fn media_list(&mut self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// ```txt
+    /// MediaConditionsList
+    ///     : MediaCondition (',' | 'and') MediaCondtion  
+    ///     ;
+    /// ```
+    fn media_conditions_list(&mut self) -> Vec<MediaCondition> {
+        let mut conditions = Vec::new();
+
+        while !self.is_next_token(TokenType::OpeningBracket) {
+            conditions.push(self.media_condition());
+
+            if self.is_next_tokens(vec![TokenType::Comma, TokenType::And]) {
+                self.consume(self.get_next_token_type().unwrap());
+            }
+        }
+
+        return conditions;
+    }
+
+    /// ```txt
+    /// MediaCondition
+    ///     : MedaiType
+    ///     | MediaFeature
+    ///     ;
+    /// ```
+    fn media_condition(&mut self) -> MediaCondition {
+        if self.is_next_token(TokenType::OpeningParenthesis) {
+            return MediaCondition::Feature(self.media_feature());
+        };
+
+        return MediaCondition::Type(self.media_type());
+    }
+
+    /// ```txt
+    /// MediaType
+    ///     : 'screen'
+    ///     | 'print'
+    ///     | 'all'
+    ///     ;
+    /// ```
+    fn media_type(&mut self) -> MediaType {
+        if self.is_next_tokens(vec![
+            TokenType::MediaScreenType,
+            TokenType::MediaPrinterType,
+            TokenType::MediaAllType,
+        ]) {
+            return match self.consume(self.get_next_token_type().unwrap()).token_type {
+                TokenType::MediaPrinterType => MediaType::Printer,
+                TokenType::MediaScreenType => MediaType::Screen,
+                TokenType::MediaAllType => MediaType::All,
+                _ => {
+                    panic!("[media_type] unexpected token")
+                }
+            };
+        }
+
+        panic!("[media_type] unexpected token")
+    }
+
+    fn media_feature(&mut self) -> MediaFeature {
+        self.consume(TokenType::OpeningParenthesis);
+
+        let name = self.consume(TokenType::Identifier).value;
+        let value = if !self.is_next_token(TokenType::ClosingParenthesis) {
+            self.consume(TokenType::Colon);
+            Some(self.consume(TokenType::Identifier).value)
+        } else {
+            None
+        };
+
+        self.consume(TokenType::ClosingParenthesis);
+
+        MediaFeature { name, value }
+    }
+
+    /// ```txt
+    /// CSSStyleRule
+    ///     : CSSSelector '{' CSSStyleDeclarationList '}'
+    ///     ;
+    /// ```
+    fn css_style_rule(&mut self) -> CSSStyleRule {
+        let selector = self.css_selector();
+        println!("{:#?}", selector);
+        self.consume(TokenType::OpeningBracket);
+        let style_declarations = self.css_style_declaration_list();
+        self.consume(TokenType::ClosingBracket);
+
+        CSSStyleRule {
+            selector,
+            style_declarations,
+        }
+    }
+
+    fn css_selector(&mut self) -> CSSSelector {
+        let mut path = Vec::new();
+
+        // todo: add better handling for the selectors
+        while !self.is_next_token(TokenType::OpeningBracket) {
+            match self.get_next_token_type() {
+                Some(token_type) => path.push(self.consume(token_type).value),
+                None => break,
+            }
+        }
+
+        CSSSelector { path }
+    }
+
+    /// ```txt
+    /// CSSStyleDeclarationList
+    ///     :  CSSStyleDeclaration ...
+    ///     ;
+    /// ```
+    fn css_style_declaration_list(&mut self) -> Vec<CSSStyleDeclaration> {
+        let mut list = Vec::new();
+
+        // todo: add condtion
+        while self.is_next_token(TokenType::Identifier) {
+            list.push(self.css_style_declaration());
+        }
+
+        return list;
+    }
+
+    /// ```txt
+    /// CSSStyleDeclaration
+    ///     : PropName ':'  PropValue ';'
+    ///     ;
+    /// ```
+    fn css_style_declaration(&mut self) -> CSSStyleDeclaration {
+        let name = self.prop_name();
+        self.consume(TokenType::Colon);
+        let value = self.prop_value();
+        self.consume(TokenType::SimiColon);
+
+        CSSStyleDeclaration { name, value }
+    }
+
+    /// ```txt
+    /// PropName
+    ///     : String
+    ///     ;
+    /// ```
+    fn prop_name(&mut self) -> String {
+        let token = self.consume(TokenType::Identifier);
+        return token.value.to_string();
+    }
+
+    /// ```txt
+    /// PropValue
+    ///     : String
+    ///     ;
+    /// ```
+    fn prop_value(&mut self) -> String {
+        let token = self.consume(TokenType::Identifier);
+        return token.value.to_string();
+    }
+
+    fn consume(&mut self, token_type: TokenType) -> Token {
+        if let Some(token) = self.lookahead.clone() {
+            if token.token_type != token_type {
+                panic!(
+                    "Unexpected token: '{:?}', expected: '{:?}'. Got '{}' at '{}'",
+                    token.token_type, token_type, token.value, self.tokenizer.cursor
+                )
+            }
+
+            // Advance to the next token
+            self.lookahead = self.tokenizer.get_next_token();
+
+            println!("next token: {:#?}", self.lookahead);
+            return token.clone();
+        }
+
+        panic!("Unexpected end of input, expected: {:?}", token_type)
+    }
+
+    fn is_next_token(&self, token_type: TokenType) -> bool {
+        if let Some(token) = self.lookahead.clone() {
+            return token.token_type == token_type;
+        }
+
+        return false;
+    }
+
+    fn is_next_tokens(&self, token_types: Vec<TokenType>) -> bool {
+        for token_type in token_types {
+            if self.is_next_token(token_type) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn get_next_token_type(&self) -> Option<TokenType> {
+        if let Some(token) = self.lookahead.clone() {
+            return Some(token.token_type);
+        }
+
+        return None;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn should_parse_css() {
+        let mut parser = CSS3Parser::new();
+        let style_sheet = parser.parse(
+            r#"
+            /* Shoud skip comments */
+
+            .header {
+                width: 10px;
+                font-size: 1rem;
+            } 
+
+            #nav {
+                height: 200px;
+            }
+
+            @media screen, printer, all and (max-width: 600px) {
+                .header {
+                    display: flex;
+                }
+
+                body {
+                    max-height: 100vh;
+                }
+            }
+
+
+            @media all {}
+        "#,
+        );
+
+        assert_eq!(
+            style_sheet,
+            CSSStyleSheet {
+                css_rules: vec![
+                    CSSRule::CSSStyleRule(CSSStyleRule {
+                        selector: CSSSelector::from_str_slice(vec![".", "header"]),
+                        style_declarations: vec![
+                            CSSStyleDeclaration {
+                                name: "width".to_string(),
+                                value: "10px".to_string()
+                            },
+                            CSSStyleDeclaration {
+                                name: "font-size".to_string(),
+                                value: "1rem".to_string()
+                            }
+                        ],
+                    }),
+                    CSSRule::CSSStyleRule(CSSStyleRule {
+                        selector: CSSSelector::from_str_slice(vec!["#", "nav"]),
+                        style_declarations: vec![CSSStyleDeclaration {
+                            name: "height".to_string(),
+                            value: "200px".to_string()
+                        }],
+                    }),
+                    CSSRule::CSSMeidaRule(CSSMeidaRule {
+                        conditions: vec![
+                            MediaCondition::Type(MediaType::Screen),
+                            MediaCondition::Type(MediaType::Printer),
+                            MediaCondition::Type(MediaType::All),
+                            MediaCondition::Feature(MediaFeature {
+                                name: "max-width".to_string(),
+                                value: Some("600px".to_string())
+                            })
+                        ],
+                        css_rules: vec![
+                            CSSRule::CSSStyleRule(CSSStyleRule {
+                                selector: CSSSelector::from_str_slice(vec![".", "header"]),
+                                style_declarations: vec![CSSStyleDeclaration {
+                                    name: "display".to_string(),
+                                    value: "flex".to_string()
+                                }],
+                            }),
+                            CSSRule::CSSStyleRule(CSSStyleRule {
+                                selector: CSSSelector::from_str_slice(vec!["body"]),
+                                style_declarations: vec![CSSStyleDeclaration {
+                                    name: "max-height".to_string(),
+                                    value: "100vh".to_string()
+                                }],
+                            })
+                        ],
+                    }),
+                    CSSRule::CSSMeidaRule(CSSMeidaRule {
+                        conditions: vec![MediaCondition::Type(MediaType::All)],
+                        css_rules: Vec::new(),
+                    })
+                ]
+            }
+        )
+    }
+}

--- a/src/css3_parser/tokenizer.rs
+++ b/src/css3_parser/tokenizer.rs
@@ -8,14 +8,19 @@ pub struct CSSTokenizer {
     raw: String,
 }
 
+impl Default for CSSTokenizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CSSTokenizer {
-    pub fn new() -> CSSTokenizer {
+    pub fn new() -> Self {
         CSSTokenizer {
             cursor: 0,
             raw: String::new(),
         }
     }
-
     pub fn init(&mut self, raw: &str) {
         self.raw = raw.to_string();
         self.cursor = 0;
@@ -60,7 +65,7 @@ impl CSSTokenizer {
             }
         }
 
-        return None;
+        None
     }
 }
 
@@ -90,7 +95,7 @@ mod test {
 
     #[test]
     fn should_match_tokens() {
-        let mut tokenizer = CSSTokenizer::new();
+        let mut tokenizer = CSSTokenizer::default();
         tokenizer.init(".><,");
         assert_eq!(tokenizer.is_eof(), false);
         assert_eq!(tokenizer.has_more_tokens(), true);
@@ -107,7 +112,7 @@ mod test {
 
     #[test]
     fn should_skip_spaces() {
-        let mut tokenizer = CSSTokenizer::new();
+        let mut tokenizer = CSSTokenizer::default();
         tokenizer.init("#id > .class {}");
 
         assert_eq!(tokenizer.is_eof(), false);
@@ -125,7 +130,7 @@ mod test {
 
     #[test]
     fn should_handle_multiline_input() {
-        let mut tokenizer = CSSTokenizer::new();
+        let mut tokenizer = CSSTokenizer::default();
 
         tokenizer.init(
             r#"

--- a/src/css3_parser/tokenizer.rs
+++ b/src/css3_parser/tokenizer.rs
@@ -1,0 +1,153 @@
+use crate::css3_parser::tokens::{Token, TOKENS_REGEXS};
+use regex::{self, Regex};
+
+/// CSS Tokenizer
+#[derive(Debug, PartialEq)]
+pub struct CSSTokenizer {
+    pub cursor: usize,
+    raw: String,
+}
+
+impl CSSTokenizer {
+    pub fn new() -> CSSTokenizer {
+        CSSTokenizer {
+            cursor: 0,
+            raw: String::new(),
+        }
+    }
+
+    pub fn init(&mut self, raw: &str) {
+        self.raw = raw.to_string();
+        self.cursor = 0;
+    }
+
+    pub fn has_more_tokens(&self) -> bool {
+        self.cursor < self.raw.len()
+    }
+
+    pub fn is_eof(&self) -> bool {
+        self.cursor == self.raw.len()
+    }
+
+    pub fn get_next_token(&mut self) -> Option<Token> {
+        if !self.has_more_tokens() {
+            return None;
+        }
+
+        let raw = &self.raw[self.cursor..];
+        for (regex, token_type) in TOKENS_REGEXS.iter() {
+            let re = Regex::new(regex).unwrap();
+            let result = re.captures(raw);
+
+            println!("RegExp Result: {:#?}", result);
+
+            if let Some(cap) = result {
+                let value = cap.get(0).unwrap().as_str();
+                self.cursor += value.len();
+
+                println!(
+                    "Tokenizer.get_next_token: value={}, token_type={:?} for raw={}",
+                    value,
+                    token_type,
+                    raw.trim(),
+                );
+
+                if token_type.is_none() {
+                    return self.get_next_token();
+                }
+
+                return Some(Token::new(token_type.unwrap(), value.to_string()));
+            }
+        }
+
+        return None;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::css3_parser::tokens::TokenType;
+
+    use super::*;
+
+    macro_rules! assert_next_token {
+        ($self:expr, $token_type:expr, $token_value:expr) => {
+            let token = $self.get_next_token();
+
+            if token.is_none() {
+                assert_eq!($token_type.is_none(), true);
+            } else {
+                assert_eq!(
+                    token.unwrap(),
+                    Token {
+                        token_type: $token_type.unwrap(),
+                        value: $token_value.unwrap().to_string(),
+                    },
+                )
+            }
+        };
+    }
+
+    #[test]
+    fn should_match_tokens() {
+        let mut tokenizer = CSSTokenizer::new();
+        tokenizer.init(".><,");
+        assert_eq!(tokenizer.is_eof(), false);
+        assert_eq!(tokenizer.has_more_tokens(), true);
+
+        assert_next_token!(tokenizer, Some(TokenType::Dot), Some("."));
+        assert_next_token!(tokenizer, Some(TokenType::GreaterThan), Some(">"));
+        assert_next_token!(tokenizer, Some(TokenType::LessThan), Some("<"));
+        assert_next_token!(tokenizer, Some(TokenType::Comma), Some(","));
+        assert_next_token!(tokenizer, None::<TokenType>, None::<&str>);
+
+        assert_eq!(tokenizer.is_eof(), true);
+        assert_eq!(tokenizer.has_more_tokens(), false);
+    }
+
+    #[test]
+    fn should_skip_spaces() {
+        let mut tokenizer = CSSTokenizer::new();
+        tokenizer.init("#id > .class {}");
+
+        assert_eq!(tokenizer.is_eof(), false);
+        assert_eq!(tokenizer.has_more_tokens(), true);
+
+        assert_next_token!(tokenizer, Some(TokenType::Hash), Some("#"));
+        assert_next_token!(tokenizer, Some(TokenType::Identifier), Some("id"));
+        assert_next_token!(tokenizer, Some(TokenType::GreaterThan), Some(">"));
+        assert_next_token!(tokenizer, Some(TokenType::Dot), Some("."));
+        assert_next_token!(tokenizer, Some(TokenType::Identifier), Some("class"));
+
+        assert_eq!(tokenizer.is_eof(), false);
+        assert_eq!(tokenizer.has_more_tokens(), true);
+    }
+
+    #[test]
+    fn should_handle_multiline_input() {
+        let mut tokenizer = CSSTokenizer::new();
+
+        tokenizer.init(
+            r#"
+            
+            .header {
+
+            }
+
+            #nav {
+
+            }
+        
+        "#,
+        );
+
+        assert_next_token!(tokenizer, Some(TokenType::Dot), Some("."));
+        assert_next_token!(tokenizer, Some(TokenType::Identifier), Some("header"));
+        tokenizer.get_next_token(); // {
+        tokenizer.get_next_token(); // }
+        assert_next_token!(tokenizer, Some(TokenType::Hash), Some("#"));
+        assert_next_token!(tokenizer, Some(TokenType::Identifier), Some("nav"));
+        tokenizer.get_next_token(); // {
+        tokenizer.get_next_token(); // }
+    }
+}

--- a/src/css3_parser/tokens.rs
+++ b/src/css3_parser/tokens.rs
@@ -31,7 +31,7 @@ impl Token {
     }
 }
 
-pub static TOKENS_REGEXS: [(&'static str, Option<TokenType>); 19] = [
+pub static TOKENS_REGEXS: [(&str, Option<TokenType>); 19] = [
     (r"^\.", Some(TokenType::Dot)),
     (r"^>", Some(TokenType::GreaterThan)),
     (r"^<", Some(TokenType::LessThan)),

--- a/src/css3_parser/tokens.rs
+++ b/src/css3_parser/tokens.rs
@@ -1,0 +1,56 @@
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum TokenType {
+    Dot,
+    GreaterThan,
+    LessThan,
+    Identifier,
+    OpeningBracket,
+    ClosingBracket,
+    OpeningParenthesis,
+    ClosingParenthesis,
+    Colon,
+    SimiColon,
+    Comma,
+    And,
+    Hash,
+    Media,
+    MediaPrinterType,
+    MediaScreenType,
+    MediaAllType,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct Token {
+    pub token_type: TokenType,
+    pub value: String,
+}
+
+impl Token {
+    pub fn new(token_type: TokenType, value: String) -> Token {
+        Token { token_type, value }
+    }
+}
+
+pub static TOKENS_REGEXS: [(&'static str, Option<TokenType>); 19] = [
+    (r"^\.", Some(TokenType::Dot)),
+    (r"^>", Some(TokenType::GreaterThan)),
+    (r"^<", Some(TokenType::LessThan)),
+    (r"^\{", Some(TokenType::OpeningBracket)),
+    (r"^\}", Some(TokenType::ClosingBracket)),
+    (r"^\(", Some(TokenType::OpeningParenthesis)),
+    (r"^\)", Some(TokenType::ClosingParenthesis)),
+    (r"^,", Some(TokenType::Comma)),
+    (r"^:", Some(TokenType::Colon)),
+    (r"^;", Some(TokenType::SimiColon)),
+    (r"^#", Some(TokenType::Hash)),
+    // Media queries tokens
+    (r"^@media", Some(TokenType::Media)),
+    (r"^printer", Some(TokenType::MediaPrinterType)),
+    (r"^screen", Some(TokenType::MediaScreenType)),
+    (r"^all", Some(TokenType::MediaAllType)),
+    (r"^and", Some(TokenType::And)),
+    // General tokens
+    (r"^(\w|-)+", Some(TokenType::Identifier)),
+    (r"^\s+", None),
+    (r"^\/\*[^\/]*\*\/", None),
+];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+#[allow(dead_code)]
 pub mod css3_parser;
 #[allow(dead_code)]
 pub mod html5_parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod css3_parser;
 #[allow(dead_code)]
 pub mod html5_parser;
 pub mod testing;


### PR DESCRIPTION
This merge request implements basic CSS parser using [recursive descent parser](https://en.wikipedia.org/wiki/Recursive_descent_parser) algorithm and [Backus-Naur form](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form) to defined the CSS grammar. 

Here is a simple example on how the parser generate the AST: 
```rs
        let mut parser = CSS3Parser::new();
        let style_sheet = parser.parse(
            r#"
            /* Shoud skip comments */

            .header {
                width: 10px;
                font-size: 1rem;
            } 

            #nav {
                height: 200px;
            }

            @media screen, printer, all and (max-width: 600px) {
                .header {
                    display: flex;
                }

                body {
                    max-height: 100vh;
                }
            }


            @media all {}
        "#,
        );

        assert_eq!(
            style_sheet,
            CSSStyleSheet {
                css_rules: vec![
                    CSSRule::CSSStyleRule(CSSStyleRule {
                        selector: CSSSelector::from_str_slice(vec![".", "header"]),
                        style_declarations: vec![
                            CSSStyleDeclaration {
                                name: "width".to_string(),
                                value: "10px".to_string()
                            },
                            CSSStyleDeclaration {
                                name: "font-size".to_string(),
                                value: "1rem".to_string()
                            }
                        ],
                    }),
                    CSSRule::CSSStyleRule(CSSStyleRule {
                        selector: CSSSelector::from_str_slice(vec!["#", "nav"]),
                        style_declarations: vec![CSSStyleDeclaration {
                            name: "height".to_string(),
                            value: "200px".to_string()
                        }],
                    }),
                    CSSRule::CSSMeidaRule(CSSMeidaRule {
                        conditions: vec![
                            MediaCondition::Type(MediaType::Screen),
                            MediaCondition::Type(MediaType::Printer),
                            MediaCondition::Type(MediaType::All),
                            MediaCondition::Feature(MediaFeature {
                                name: "max-width".to_string(),
                                value: Some("600px".to_string())
                            })
                        ],
                        css_rules: vec![
                            CSSRule::CSSStyleRule(CSSStyleRule {
                                selector: CSSSelector::from_str_slice(vec![".", "header"]),
                                style_declarations: vec![CSSStyleDeclaration {
                                    name: "display".to_string(),
                                    value: "flex".to_string()
                                }],
                            }),
                            CSSRule::CSSStyleRule(CSSStyleRule {
                                selector: CSSSelector::from_str_slice(vec!["body"]),
                                style_declarations: vec![CSSStyleDeclaration {
                                    name: "max-height".to_string(),
                                    value: "100vh".to_string()
                                }],
                            })
                        ],
                    }),
                    CSSRule::CSSMeidaRule(CSSMeidaRule {
                        conditions: vec![MediaCondition::Type(MediaType::All)],
                        css_rules: Vec::new(),
                    })
                ]
            }
        )
```