### PR TITLE
Implemented adjusted_insert_location function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ colored = "2.0.4"
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 test-case = "3.2.1"
+
+[features]
+# Enables extended debugging information during parsing.
+debug_parser = []

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
 
         let mut test_idx = 1;
         for test in fixture_file.tests {
-            if test_idx == 27 {
+            if test_idx == 31 {
                 run_tree_test(test_idx, &test, &mut results);
             }
             test_idx += 1;

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -3,6 +3,7 @@ use crate::html5_parser::node::data::comment::CommentData;
 use crate::html5_parser::node::data::document::DocumentData;
 use crate::html5_parser::node::data::element::ElementData;
 use crate::html5_parser::node::data::text::TextData;
+use core::fmt::Debug;
 use derive_more::Display;
 use std::collections::HashMap;
 
@@ -35,7 +36,7 @@ pub enum NodeData {
 }
 
 /// Id used to identify a node
-#[derive(Copy, Debug, Default, Eq, Hash, PartialEq, Display)]
+#[derive(Copy, Debug, Default, Eq, Hash, PartialEq, Display, PartialOrd)]
 pub struct NodeId(pub(crate) usize);
 
 impl From<NodeId> for usize {
@@ -88,7 +89,7 @@ impl NodeId {
 }
 
 /// Node that resembles a DOM node
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct Node {
     /// ID of the node, 0 is always the root / document node
     pub id: NodeId,
@@ -106,6 +107,20 @@ pub struct Node {
     pub data: NodeData,
     /// pointer to document this node is attached to
     pub document: DocumentHandle,
+}
+
+impl Debug for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Node");
+        debug.field("id", &self.id);
+        debug.field("named_id", &self.named_id);
+        debug.field("parent", &self.parent);
+        debug.field("children", &self.children);
+        debug.field("name", &self.name);
+        debug.field("namespace", &self.namespace);
+        debug.field("data", &self.data);
+        debug.finish()
+    }
 }
 
 impl Node {

--- a/src/html5_parser/node/data/document.rs
+++ b/src/html5_parser/node/data/document.rs
@@ -1,10 +1,19 @@
-#[derive(Debug, PartialEq, Clone)]
+use core::fmt::{Debug, Formatter};
+use std::fmt;
+
+#[derive(PartialEq, Clone)]
 /// Data structure for document nodes
 pub struct DocumentData {}
 
 impl Default for DocumentData {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Debug for DocumentData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "[DocumentData]")
     }
 }
 

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -64,7 +64,8 @@ impl<'stream> Html5Parser<'stream> {
             let formatting_element_id = self.active_formatting_elements[formatting_element_idx_afe]
                 .node_id()
                 .expect("formatting element not found");
-            let formatting_element_node = get_node_by_id!(self, formatting_element_id).clone();
+            let formatting_element_node =
+                get_node_by_id!(self.document, formatting_element_id).clone();
 
             // Step 4.4
             if !self.open_elements_has_id(formatting_element_id) {
@@ -111,7 +112,7 @@ impl<'stream> Html5Parser<'stream> {
 
             let furthest_block_idx_oe = furthest_block_idx_oe.expect("furthest block not found");
             let furthest_block_id = open_elements_get!(self, furthest_block_idx_oe).id;
-            let furthest_block_node = get_node_by_id!(self, furthest_block_id).clone();
+            let furthest_block_node = get_node_by_id!(self.document, furthest_block_id).clone();
 
             // Step 4.9
             // Find the index of the wanted formatting element id in the open elements stack
@@ -137,7 +138,7 @@ impl<'stream> Html5Parser<'stream> {
                 // Step 4.13.2
                 node_idx_oe -= 1;
                 let node_id = open_elements_get!(self, node_idx_oe).id;
-                let node = get_node_by_id!(self, node_id).clone();
+                let node = get_node_by_id!(self.document, node_id).clone();
 
                 // Step 4.13.3
                 if node_id == formatting_element_id {
@@ -293,7 +294,7 @@ impl<'stream> Html5Parser<'stream> {
                 }
                 ActiveElement::Node(node_id) => {
                     // Check if the given node is an element with the given subject
-                    let node = get_node_by_id!(self, node_id).clone();
+                    let node = get_node_by_id!(self.document, node_id).clone();
                     if let NodeData::Element(element) = &node.data {
                         if element.name == subject {
                             return Some(idx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate alloc;
+extern crate core;
 
 pub mod api;
 #[allow(dead_code)]


### PR DESCRIPTION
working version of the adjusted-insert-location.

This PR should implement a working algorithm as defined by https://html.spec.whatwg.org/multipage/parsing.html#creating-and-inserting-nodes

The main idea is to have the adjusted-insert-location function return not only a node-id which is the node that needs to be returned, but it's possible that this node is not in the main document, but instead in a template's document(fragment).  Besides this, it's possible to have a node inserted between children of a certain node. 

This means we have a new `NodeInsertLocation` structure that contains a document handle, a node_id, and a position.

  - handle defines which document(fragment) to insert into
  - node_id is the node in which to insert the new node
  - position is an optional index where the node should be inserted in the current children (0 = at the front, 1 = second place etc). If the position is larger than the length, it will be added to the end. If there is no position given (`None`), it will be added to the end of the children as well.
