### PR TITLE
Add `DocumentHandle` to `ElementData` and `ElementAttributes`

### DIFF
--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -158,7 +158,7 @@ impl Node {
             named_id: None,
             parent: None,
             children: vec![],
-            data: NodeData::Element(ElementData::with_name_and_attributes(name, attributes)),
+            data: NodeData::Element(ElementData::with_name_and_attributes(Default::default(), Document::clone(document), name, attributes)),
             name: name.to_string(),
             namespace: Some(namespace.into()),
             document: Document::clone(document),

--- a/src/html5_parser/node/data/element.rs
+++ b/src/html5_parser/node/data/element.rs
@@ -28,7 +28,11 @@ impl ElementAttributes {
         }
     }
 
-    pub(crate) fn with_attributes(node_id: NodeId, document: DocumentHandle, attributes: HashMap<String, String>) -> Self {
+    pub(crate) fn with_attributes(
+        node_id: NodeId,
+        document: DocumentHandle,
+        attributes: HashMap<String, String>,
+    ) -> Self {
         Self {
             node_id,
             document,
@@ -130,7 +134,11 @@ impl ElementData {
         Self {
             node_id,
             name: name.into(),
-            attributes: ElementAttributes::with_attributes(node_id, Document::clone(&document), attributes),
+            attributes: ElementAttributes::with_attributes(
+                node_id,
+                Document::clone(&document),
+                attributes,
+            ),
             classes: ElementClass::new(),
             force_async: false,
             template_contents: None,

--- a/src/html5_parser/node/data/element.rs
+++ b/src/html5_parser/node/data/element.rs
@@ -1,18 +1,18 @@
 use crate::html5_parser::element_class::ElementClass;
-use crate::html5_parser::parser::document::DocumentFragment;
+use crate::html5_parser::node::NodeId;
+use crate::html5_parser::parser::document::{Document, DocumentFragment, DocumentHandle};
 use std::collections::hash_map::Iter;
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone)]
 /// Data structure for storing element attributes (ie: class="foo")
 pub(crate) struct ElementAttributes {
-    pub(crate) attributes: HashMap<String, String>,
-}
-
-impl Default for ElementAttributes {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// Numerical ID of the node these attributes are tied to
+    pub(crate) node_id: NodeId,
+    /// Pointer to the document that the node associated with these attributes are tied to
+    pub(crate) document: DocumentHandle,
+    /// Key-value pair of all attributes
+    attributes: HashMap<String, String>,
 }
 
 /// This is a very thin wrapper around a HashMap.
@@ -20,14 +20,18 @@ impl Default for ElementAttributes {
 /// This "controls" what you're allowed to do with an element's attributes
 /// so there are no unexpected modifications.
 impl ElementAttributes {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(node_id: NodeId, document: DocumentHandle) -> Self {
         Self {
+            node_id,
+            document,
             attributes: HashMap::new(),
         }
     }
 
-    pub(crate) fn with_attributes(attributes: HashMap<String, String>) -> Self {
+    pub(crate) fn with_attributes(node_id: NodeId, document: DocumentHandle, attributes: HashMap<String, String>) -> Self {
         Self {
+            node_id,
+            document,
             attributes: attributes.clone(),
         }
     }
@@ -78,11 +82,18 @@ impl ElementAttributes {
             self.insert(key, value);
         }
     }
+
+    /// Clones the internal map of attributes (NOT the attributes object itself)
+    pub(crate) fn clone_map(&self) -> HashMap<String, String> {
+        self.attributes.clone()
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
 /// Data structure for element nodes
 pub struct ElementData {
+    /// Numerical ID of the node this data is attached to
+    pub(crate) node_id: NodeId,
     /// Name of the element (e.g., div)
     pub(crate) name: String,
     /// Element's attributes stored as key-value pairs
@@ -93,39 +104,45 @@ pub struct ElementData {
     pub(crate) force_async: bool,
     // Template contents (when it's a template element)
     pub(crate) template_contents: Option<DocumentFragment>,
-}
-
-impl Default for ElementData {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// Pointer to the document the node associated with this data is tied to
+    pub(crate) document: DocumentHandle,
 }
 
 impl ElementData {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(node_id: NodeId, document: DocumentHandle) -> Self {
         Self {
+            node_id,
             name: "".to_string(),
-            attributes: ElementAttributes::new(),
+            attributes: ElementAttributes::new(node_id, Document::clone(&document)),
             classes: ElementClass::new(),
             force_async: false,
             template_contents: None,
+            document,
         }
     }
 
     pub(crate) fn with_name_and_attributes(
+        node_id: NodeId,
+        document: DocumentHandle,
         name: &str,
         attributes: HashMap<String, String>,
     ) -> Self {
         Self {
+            node_id,
             name: name.into(),
-            attributes: ElementAttributes::with_attributes(attributes),
+            attributes: ElementAttributes::with_attributes(node_id, Document::clone(&document), attributes),
             classes: ElementClass::new(),
             force_async: false,
             template_contents: None,
+            document,
         }
     }
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub(crate) fn set_id(&mut self, node_id: NodeId) {
+        self.node_id = node_id;
     }
 }

--- a/src/html5_parser/parser.rs
+++ b/src/html5_parser/parser.rs
@@ -3516,7 +3516,6 @@ impl<'stream> Html5Parser<'stream> {
 mod test {
     use super::*;
     use crate::html5_parser::input_stream::Encoding;
-    use crate::html5_parser::node::data::element::ElementData;
 
     macro_rules! node_create {
         ($self:expr, $name:expr) => {{
@@ -3772,19 +3771,19 @@ mod test {
         // document -> html -> head -> body -> div
         let div = binding.get_node_by_id(4.into()).unwrap();
 
-        let NodeData::Element(ElementData { classes, .. }) = &div.data else {
+        let NodeData::Element(element) = &div.data else {
             panic!()
         };
 
-        assert_eq!(classes.len(), 3);
+        assert_eq!(element.classes.len(), 3);
 
-        assert!(classes.contains("one"));
-        assert!(classes.contains("two"));
-        assert!(classes.contains("three"));
+        assert!(element.classes.contains("one"));
+        assert!(element.classes.contains("two"));
+        assert!(element.classes.contains("three"));
 
-        assert!(classes.is_active("one"));
-        assert!(classes.is_active("two"));
-        assert!(classes.is_active("three"));
+        assert!(element.classes.is_active("one"));
+        assert!(element.classes.is_active("two"));
+        assert!(element.classes.is_active("three"));
     }
 
     #[test]
@@ -3804,19 +3803,19 @@ mod test {
         // document -> html -> head -> body -> div
         let div = binding.get_node_by_id(4.into()).unwrap();
 
-        let NodeData::Element(ElementData { classes, .. }) = &div.data else {
+        let NodeData::Element(element) = &div.data else {
             panic!()
         };
 
-        assert_eq!(classes.len(), 3);
+        assert_eq!(element.classes.len(), 3);
 
-        assert!(classes.contains("one"));
-        assert!(classes.contains("two"));
-        assert!(classes.contains("three"));
+        assert!(element.classes.contains("one"));
+        assert!(element.classes.contains("two"));
+        assert!(element.classes.contains("three"));
 
-        assert!(classes.is_active("one"));
-        assert!(classes.is_active("two"));
-        assert!(classes.is_active("three"));
+        assert!(element.classes.is_active("one"));
+        assert!(element.classes.is_active("two"));
+        assert!(element.classes.is_active("three"));
     }
 
     #[test]

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -1,4 +1,3 @@
-use crate::html5_parser::node::data::element::ElementData;
 use crate::html5_parser::node::{Node, NodeData, NodeId, HTML_NAMESPACE};
 use crate::html5_parser::parser::{ActiveElement, Html5Parser, Scope};
 use crate::html5_parser::tokenizer::token::Token;
@@ -172,9 +171,7 @@ impl<'stream> Html5Parser<'stream> {
                 // Step 4.13.6
                 // replace the old node with the new replacement node
                 let node_attributes = match node.data {
-                    NodeData::Element(ElementData { attributes, .. }) => {
-                        attributes.clone_map()
-                    }
+                    NodeData::Element(element) => element.attributes.clone_map(),
                     _ => HashMap::new(),
                 };
 
@@ -223,12 +220,10 @@ impl<'stream> Html5Parser<'stream> {
 
             // Step 4.15
             let new_element = match formatting_element_node.data {
-                NodeData::Element(ElementData {
-                    name, attributes, ..
-                }) => Node::new_element(
+                NodeData::Element(element) => Node::new_element(
                     &self.document,
-                    name.as_str(),
-                    attributes.clone_map(),
+                    element.name.as_str(),
+                    element.attributes.clone_map(),
                     HTML_NAMESPACE,
                 ),
                 _ => panic!("formatting element is not an element"),
@@ -299,8 +294,8 @@ impl<'stream> Html5Parser<'stream> {
                 ActiveElement::Node(node_id) => {
                     // Check if the given node is an element with the given subject
                     let node = get_node_by_id!(self, node_id).clone();
-                    if let NodeData::Element(ElementData { name, .. }) = &node.data {
-                        if name == subject {
+                    if let NodeData::Element(element) = &node.data {
+                        if element.name == subject {
                             return Some(idx);
                         }
                     }

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -173,7 +173,7 @@ impl<'stream> Html5Parser<'stream> {
                 // replace the old node with the new replacement node
                 let node_attributes = match node.data {
                     NodeData::Element(ElementData { attributes, .. }) => {
-                        attributes.attributes.clone()
+                        attributes.clone_map()
                     }
                     _ => HashMap::new(),
                 };
@@ -228,7 +228,7 @@ impl<'stream> Html5Parser<'stream> {
                 }) => Node::new_element(
                     &self.document,
                     name.as_str(),
-                    attributes.attributes.clone(),
+                    attributes.clone_map(),
                     HTML_NAMESPACE,
                 ),
                 _ => panic!("formatting element is not an element"),

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -304,6 +304,12 @@ impl PartialEq for DocumentHandle {
     }
 }
 
+impl Clone for DocumentHandle {
+    fn clone(&self) -> DocumentHandle {
+        DocumentHandle(Rc::clone(&self.0))
+    }
+}
+
 impl Eq for DocumentHandle {}
 
 impl DocumentHandle {

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -311,6 +311,10 @@ impl PartialEq for DocumentHandle {
     }
 }
 
+// NOTE: it is preferred to use Document::clone() when
+// copying a DocumentHandle reference. However, for
+// any structs using this handle that use #[derive(Clone)],
+// this implementation is required.
 impl Clone for DocumentHandle {
     fn clone(&self) -> DocumentHandle {
         DocumentHandle(Rc::clone(&self.0))

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -1,5 +1,5 @@
 use crate::html5_parser::node::arena::NodeArena;
-use crate::html5_parser::node::data::{comment::CommentData, element::ElementData, text::TextData};
+use crate::html5_parser::node::data::{comment::CommentData, text::TextData};
 use crate::html5_parser::node::NodeType;
 use crate::html5_parser::node::{Node, NodeData, NodeId};
 use crate::html5_parser::node::{NodeTrait, HTML_NAMESPACE};
@@ -251,11 +251,9 @@ impl Document {
             NodeData::Comment(CommentData { value, .. }) => {
                 _ = writeln!(f, "{}<!-- {} -->", buffer, value);
             }
-            NodeData::Element(ElementData {
-                name, attributes, ..
-            }) => {
-                _ = write!(f, "{}<{}", buffer, name);
-                for (key, value) in attributes.iter() {
+            NodeData::Element(element) => {
+                _ = write!(f, "{}<{}", buffer, element.name);
+                for (key, value) in element.attributes.iter() {
                     _ = write!(f, " {}={}", key, value);
                 }
                 _ = writeln!(f, ">");


### PR DESCRIPTION
This is the first step in refactoring `ElementAttributes.insert()` to allow direct modification of the DOM which will remove `Document.set_named_id`. See [this discussion](https://github.com/gosub-browser/gosub-engine/discussions/123) for more details.

However, I didn't want to make too many changes at once to make it hard to follow, so this PR does the following things:
* Adds the `DocumentHandle` shared pointer to `ElementData` and `ElementAttributes`
* Moves `ElementData` to the heap with `Box<>` now that it has grown a little large
    * NOTE: we are not able to pattern match on attributes anymore with `Box<>` (at least, while the other items in the enum are stack-allocated) so any usage of `NodeData::Element` had to be slightly refactored
* Adds the `node_id` to the constructor for `ElementData` as we need to know the node ID when making changes to the DOM (later)
    * NOTE: `Document.add_node` was changed to update the node ID within the element data. In a follow up PR when `ElementAttributes.insert()` is refactored we will be able to clean up this method quite a bit; see `TODO:` comments
    * A new test was added to verify that the IDs in the underlying `ElementData` structs are properly updated when adding a node to the DOM (when node's are first created, they all use the default ID which is 0)
* Small cleanup in tests changing `NodeId(X)` to `NodeId::from(X)` to have some sort of consistency