### PR TITLE
Begin to move loading of parser test fixtures to their own module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ keywords = ["html5", "parser"]
 name = "tokenizer"
 path = "tests/tokenizer.rs"
 
+[[test]]
+name = "tree_construction"
+path = "tests/tree_construction.rs"
+
 [[bench]]
 name = "tokenizer"
 harness = false

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build: ## Build	the project
 	cargo build
 
 fix:
+	cargo fmt
 	cargo clippy --fix --allow-dirty --allow-staged
 
 test_unit:

--- a/src/css/tokenizer.rs
+++ b/src/css/tokenizer.rs
@@ -91,13 +91,13 @@ mod test {
         let mut tokenizer = Tokenizer::default();
         tokenizer.init("123 -ident-test-1");
 
-        assert_eq!(tokenizer.is_eof(), false);
-        assert_eq!(tokenizer.has_more_tokens(), true);
+        assert!(!tokenizer.is_eof());
+        assert!(tokenizer.has_more_tokens());
 
         assert_next_token!(tokenizer, Some(TokenType::Number), Some("123"));
         assert_next_token!(tokenizer, Some(TokenType::Ident), Some("-ident-test-1"));
 
-        assert_eq!(tokenizer.is_eof(), true);
-        assert_eq!(tokenizer.has_more_tokens(), false);
+        assert!(tokenizer.is_eof());
+        assert!(!tokenizer.has_more_tokens());
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,1 +1,4 @@
 pub mod tokenizer;
+pub mod tree_construction;
+
+pub const FIXTURE_ROOT: &str = "./tests/data/html5lib-tests";

--- a/src/testing/tokenizer.rs
+++ b/src/testing/tokenizer.rs
@@ -1,3 +1,14 @@
+use super::FIXTURE_ROOT;
+use crate::html5_parser::{
+    error_logger::ErrorLogger,
+    input_stream::InputStream,
+    tokenizer::{
+        state::State as TokenState,
+        token::{Attribute, Token, TokenType},
+        {Options, Tokenizer},
+    },
+};
+use crate::types::Result;
 use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 use serde_derive::{Deserialize, Serialize};
@@ -9,21 +20,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::html5_parser::tokenizer::token::{Attribute, Token, TokenType};
-use crate::html5_parser::{
-    error_logger::ErrorLogger,
-    input_stream::InputStream,
-    tokenizer::{
-        state::State as TokenState,
-        {Options, Tokenizer},
-    },
-};
-
-pub const FIXTURE_ROOT: &str = "./tests/data/html5lib-tests";
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Root {
+pub struct FixtureFile {
     pub tests: Vec<Test>,
 }
 
@@ -367,21 +366,21 @@ pub fn from_utf16_lossy(input: &str) -> String {
     .to_string()
 }
 
-pub fn fixture_from_filename(filename: &str) -> Result<Root, serde_json::Error> {
+pub fn fixture_from_filename(filename: &str) -> Result<FixtureFile> {
     let path = PathBuf::from(FIXTURE_ROOT).join("tokenizer").join(filename);
     fixture_from_path(&path)
 }
 
-pub fn fixture_from_path<P>(path: &P) -> Result<Root, serde_json::Error>
+pub fn fixture_from_path<P>(path: &P) -> Result<FixtureFile>
 where
     P: AsRef<Path>,
 {
     let contents = fs::read_to_string(path).unwrap();
     // TODO: use thiserror to translate library errors
-    serde_json::from_str(&contents)
+    Ok(serde_json::from_str(&contents)?)
 }
 
-pub fn fixtures() -> impl Iterator<Item = Root> {
+pub fn fixtures() -> impl Iterator<Item = FixtureFile> {
     let root = PathBuf::from(FIXTURE_ROOT).join("tokenizer");
     fs::read_dir(root).unwrap().flat_map(|entry| {
         let path = format!("{}", entry.unwrap().path().display());

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -1,0 +1,165 @@
+use super::FIXTURE_ROOT;
+use crate::types::Result;
+use regex::Regex;
+use std::{
+    fs::{self, File},
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, PartialEq)]
+pub struct FixtureFile {
+    pub tests: Vec<Test>,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Error {
+    pub code: String,
+    pub line: i64,
+    pub col: i64,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Test {
+    /// Filename of the test
+    pub file_path: String,
+    /// Line number of the test
+    pub line: usize,
+    /// input stream
+    pub data: String,
+    /// errors
+    pub errors: Vec<Error>,
+    /// document tree
+    pub document: Vec<String>,
+    /// fragment
+    document_fragment: Vec<String>,
+}
+
+impl Test {
+    // Check that the tree construction code doesn't panic
+    pub fn run(&self) {
+        // TODO: Fill this in later
+    }
+
+    // Verify that the tree construction code obtains the right result
+    pub fn assert_valid(&self) {
+        // TODO: Fill this in later
+    }
+}
+
+pub fn fixture_from_filename(filename: &str) -> Result<FixtureFile> {
+    let path = PathBuf::from(FIXTURE_ROOT)
+        .join("tree-construction")
+        .join(filename);
+    fixture_from_path(&path)
+}
+
+/// Read given tests file and extract all test data
+pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
+    let file = File::open(path)?;
+    // TODO: use thiserror to translate library errors
+    let reader = BufReader::new(file);
+
+    let mut tests = Vec::new();
+    let mut current_test = Test {
+        file_path: path.to_str().unwrap().to_string(),
+        line: 1,
+        data: "".to_string(),
+        errors: vec![],
+        document: vec![],
+        document_fragment: vec![],
+    };
+    let mut section: Option<&str> = None;
+
+    for (line_num, line) in reader.lines().enumerate() {
+        let line = line?;
+
+        if line.starts_with("#data") {
+            if !current_test.data.is_empty()
+                || !current_test.errors.is_empty()
+                || !current_test.document.is_empty()
+            {
+                current_test.data = current_test.data.trim_end().to_string();
+                tests.push(current_test);
+                current_test = Test {
+                    file_path: path.to_str().unwrap().to_string(),
+                    line: line_num,
+                    data: "".to_string(),
+                    errors: vec![],
+                    document: vec![],
+                    document_fragment: vec![],
+                };
+            }
+            section = Some("data");
+        } else if line.starts_with('#') {
+            section = match line.as_str() {
+                "#errors" => Some("errors"),
+                "#document" => Some("document"),
+                _ => None,
+            };
+        } else if let Some(sec) = section {
+            match sec {
+                "data" => current_test.data.push_str(&line),
+                "errors" => {
+                    let re = Regex::new(r"\((?P<line>\d+),(?P<col>\d+)\): (?P<code>.+)").unwrap();
+                    if let Some(caps) = re.captures(&line) {
+                        let line = caps.name("line").unwrap().as_str().parse::<i64>().unwrap();
+                        let col = caps.name("col").unwrap().as_str().parse::<i64>().unwrap();
+                        let code = caps.name("code").unwrap().as_str().to_string();
+
+                        current_test.errors.push(Error { code, line, col });
+                    }
+                }
+                "document" => current_test.document.push(line),
+                "document_fragment" => current_test.document_fragment.push(line),
+                _ => (),
+            }
+        }
+    }
+
+    // Push the last test if it has data
+    if !current_test.data.is_empty()
+        || !current_test.errors.is_empty()
+        || !current_test.document.is_empty()
+    {
+        current_test.data = current_test.data.trim_end().to_string();
+        tests.push(current_test);
+    }
+
+    Ok(FixtureFile {
+        tests,
+        path: path.to_path_buf(),
+    })
+}
+
+fn use_fixture(filenames: &[&str], path: &Path) -> bool {
+    if !path.is_file() || path.extension().expect("file ending") != "dat" {
+        return false;
+    }
+
+    if filenames.is_empty() {
+        return true;
+    }
+
+    filenames.iter().any(|filename| path.ends_with(filename))
+}
+
+pub fn fixtures(filenames: Option<&[&str]>) -> Result<Vec<FixtureFile>> {
+    let root = PathBuf::from(FIXTURE_ROOT).join("tree-construction");
+    let filenames = filenames.unwrap_or_default();
+    let mut files = vec![];
+
+    for entry in fs::read_dir(root)? {
+        let path = entry?.path();
+
+        if !use_fixture(filenames, &path) {
+            continue;
+        }
+
+        let file = fixture_from_path(&path)?;
+        files.push(file);
+    }
+
+    Ok(files)
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,9 @@ pub enum Error {
 
     #[error("utf8 conversion error: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),
+
+    #[error("json parsing error: {0}")]
+    JsonSerde(#[from] serde_json::Error),
 }
 
 /// Result that can be returned which holds either T or an Error

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,3 +2,4 @@ extern crate regex;
 extern crate serde_derive;
 
 mod tokenizer;
+mod tree_construction;

--- a/tests/tree_construction.rs
+++ b/tests/tree_construction.rs
@@ -1,0 +1,28 @@
+use gosub_engine::testing::tree_construction::fixture_from_filename;
+use lazy_static::lazy_static;
+use std::collections::HashSet;
+use test_case::test_case;
+
+const DISABLED_CASES: &[&str] = &[];
+
+lazy_static! {
+    static ref DISABLED: HashSet<String> = DISABLED_CASES
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+}
+
+#[test_case("tests1.dat")]
+fn tree_construction(filename: &str) {
+    let fixture_file = fixture_from_filename(filename).expect("fixture");
+
+    for test in fixture_file.tests {
+        if DISABLED.contains(&test.data) {
+            // Check that we don't panic
+            test.run();
+            continue;
+        }
+
+        test.assert_valid();
+    }
+}


### PR DESCRIPTION
This PR begins to move some of the parsing fixture handling code into a separate module in prepapartion for including parsing tests in the CI run. I stopped at a certain point in order to avoid changing the behavior of `parser_test`.  Still thinking through the approach to use here.

Behavior on `main`:

![2023-10-15_13-46](https://github.com/gosub-browser/gosub-engine/assets/760949/ddca989d-92f3-4ee3-a8c3-e4c6dc79422a)

Behavior on this branch:

![2023-10-15_13-57](https://github.com/gosub-browser/gosub-engine/assets/760949/db27f889-99e5-4c1b-aafc-8b975f16643f)

![2023-10-15_14-00](https://github.com/gosub-browser/gosub-engine/assets/760949/795f6173-8646-46b8-82fb-c4fcbda4c39b)