### PR TITLE
Refactor `ElementAttributes` to directly modify DOM

### DIFF
--- a/src/css/tokenizer.rs
+++ b/src/css/tokenizer.rs
@@ -91,13 +91,13 @@ mod test {
         let mut tokenizer = Tokenizer::default();
         tokenizer.init("123 -ident-test-1");
 
-        assert_eq!(tokenizer.is_eof(), false);
-        assert_eq!(tokenizer.has_more_tokens(), true);
+        assert!(!tokenizer.is_eof());
+        assert!(tokenizer.has_more_tokens());
 
         assert_next_token!(tokenizer, Some(TokenType::Number), Some("123"));
         assert_next_token!(tokenizer, Some(TokenType::Ident), Some("-ident-test-1"));
 
-        assert_eq!(tokenizer.is_eof(), true);
-        assert_eq!(tokenizer.has_more_tokens(), false);
+        assert!(tokenizer.is_eof());
+        assert!(!tokenizer.has_more_tokens());
     }
 }

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -224,39 +224,6 @@ impl Node {
 
         false
     }
-
-    /// Check if node has a named ID
-    pub fn has_named_id(&self) -> bool {
-        if self.type_of() != NodeType::Element {
-            return false;
-        }
-
-        self.named_id.is_some()
-    }
-
-    /// Set named ID (only applies to Element type, does nothing otherwise)
-    pub fn set_named_id(&mut self, named_id: &str) {
-        if self.type_of() == NodeType::Element {
-            self.named_id = Some(named_id.to_owned());
-            if let NodeData::Element(element) = &mut self.data {
-                element.attributes.insert("id", named_id);
-            }
-        }
-    }
-
-    /// Get named ID. If not present or type is not Element, returns None
-    pub fn get_named_id(&self) -> Option<String> {
-        if self.type_of() != NodeType::Element {
-            return None;
-        }
-
-        if !self.has_named_id() {
-            return None;
-        }
-
-        // don't want to return the actual internal String
-        self.named_id.clone()
-    }
 }
 
 pub trait NodeTrait {

--- a/src/html5_parser/node/data/element.rs
+++ b/src/html5_parser/node/data/element.rs
@@ -45,8 +45,44 @@ impl ElementAttributes {
         self.attributes.contains_key(name)
     }
 
+    /// according to HTML5 spec: 3.2.3.1
+    /// https://www.w3.org/TR/2011/WD-html5-20110405/elements.html#the-id-attribute
+    fn validate_named_id(&self, named_id: &str) -> bool {
+        if named_id.contains(char::is_whitespace) {
+            return false;
+        }
+
+        if named_id.is_empty() {
+            return false;
+        }
+
+        // must contain at least one character, but
+        // doesn't specify it should *start* with a character
+        if !named_id.contains(char::is_alphabetic) {
+            return false;
+        }
+
+        true
+    }
+
     /// Inserts a new attribute into the map.
     pub(crate) fn insert(&mut self, name: &str, value: &str) {
+        // handle special cases
+        match name {
+            "id" => {
+                if self.validate_named_id(value) && !self.document.get().named_id_elements.contains_key(value) {
+                    if let Some(old_named_id) = self.attributes.get("id") {
+                        self.document.get_mut().named_id_elements.remove(old_named_id);
+                    }
+                    self.document.get_mut().named_id_elements.insert(name.to_owned(), self.node_id);
+                }
+            }
+            "class" => {
+                todo!()
+            }
+            _ => {}
+        }
+
         self.attributes.insert(name.to_owned(), value.to_owned());
     }
 
@@ -152,5 +188,6 @@ impl ElementData {
 
     pub(crate) fn set_id(&mut self, node_id: NodeId) {
         self.node_id = node_id;
+        self.attributes.node_id = node_id;
     }
 }

--- a/src/html5_parser/node/data/element.rs
+++ b/src/html5_parser/node/data/element.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 #[derive(Debug, PartialEq, Clone)]
 /// Data structure for storing element attributes (ie: class="foo")
 pub(crate) struct ElementAttributes {
-    /// Numerical ID of the node these attributes are tied to
     pub(crate) node_id: NodeId,
     /// Pointer to the document that the node associated with these attributes are tied to
     pub(crate) document: DocumentHandle,

--- a/src/html5_parser/node/data/element.rs
+++ b/src/html5_parser/node/data/element.rs
@@ -66,22 +66,6 @@ impl ElementAttributes {
 
     /// Inserts a new attribute into the map.
     pub(crate) fn insert(&mut self, name: &str, value: &str) {
-        // handle special cases
-        match name {
-            "id" => {
-                if self.validate_named_id(value) && !self.document.get().named_id_elements.contains_key(value) {
-                    if let Some(old_named_id) = self.attributes.get("id") {
-                        self.document.get_mut().named_id_elements.remove(old_named_id);
-                    }
-                    self.document.get_mut().named_id_elements.insert(name.to_owned(), self.node_id);
-                }
-            }
-            "class" => {
-                todo!()
-            }
-            _ => {}
-        }
-
         self.attributes.insert(name.to_owned(), value.to_owned());
     }
 
@@ -188,5 +172,12 @@ impl ElementData {
     pub(crate) fn set_id(&mut self, node_id: NodeId) {
         self.node_id = node_id;
         self.attributes.node_id = node_id;
+    }
+
+    pub(crate) fn with_attributes<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut ElementAttributes),
+    {
+        f(&mut self.attributes)
     }
 }

--- a/src/html5_parser/parser.rs
+++ b/src/html5_parser/parser.rs
@@ -3834,14 +3834,14 @@ mod test {
 
         let binding = document.get();
 
-        let div1 = binding.get_node_by_id(NodeId(4)).unwrap();
-        assert!(!div1.has_named_id());
+        let div1 = binding.get_node_by_named_id("my id");
+        assert!(div1.is_none());
 
-        let div2 = binding.get_node_by_id(NodeId(5)).unwrap();
-        assert!(!div2.has_named_id());
+        let div2 = binding.get_node_by_named_id("123");
+        assert!(div2.is_none());
 
-        let div3 = binding.get_node_by_id(NodeId(6)).unwrap();
-        assert!(!div3.has_named_id());
+        let div3 = binding.get_node_by_named_id("\"\"");
+        assert!(div3.is_none());
     }
 
     #[test]
@@ -3863,8 +3863,15 @@ mod test {
             assert_eq!(div.id, NodeId(4));
         }
 
-        let mut binding = document.get_mut();
-        binding.set_node_named_id(NodeId(4), "otherid");
-        assert!(binding.get_node_by_named_id("myid").is_none());
+        if let Some(node) = document.get_mut().get_node_by_id_mut(NodeId::from(4)) {
+            if let NodeData::Element(element) = &mut node.data {
+                element.attributes.insert("id", "otherid");
+            }
+        }
+        
+        // since our implementation only allows binding to one node
+        // per ID, once the ID changes on that element it's bound to,
+        // the old ID should no longer be searchable
+        assert!(document.get().get_node_by_named_id("myid").is_none());
     }
 }


### PR DESCRIPTION
(DRAFT PR)

This is the progress on refactoring `ElementAttributes.insert` to directly modify the DOM in the special cases of `id` and `class` attribute. `Document.named_id_elements` will also eventually be renamed to `queryable_id_nodes` and `queryable_class_nodes` will be introduced at a later point when `Document.get_node_by_class_name(...)` is introduced.

Current state, some of the tests need to be refactored slightly to handle the API changes (some methods in `Node` and `Document` are removed) and the `class` special case needs to be implemented