### PR TITLE
Incorporate tree-construction tests into CI run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ path = "tests/tree_construction.rs"
 name = "tokenizer"
 harness = false
 
+[[bench]]
+name = "tree_construction"
+harness = false
+
 [dependencies]
 phf = { version = "0.11.2", features = ["macros"] }
 derive_more = "0.99"

--- a/benches/tree_construction.rs
+++ b/benches/tree_construction.rs
@@ -1,21 +1,19 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use gosub_engine::testing::tokenizer;
+use gosub_engine::testing::tree_construction;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    // Criterion can report inconsistent results from run to run in some cases.  We attempt to
-    // minimize that in this setup.
-    // https://stackoverflow.com/a/74136347/61048
-    let mut group = c.benchmark_group("Tokenizer");
+    let mut group = c.benchmark_group("Tree construction");
     group.significance_level(0.1).sample_size(500);
 
-    // Fetch the files outside of the closure to avoid issues with file io
-    let fixtures = tokenizer::fixtures().collect::<Vec<_>>();
+    // Careful about reading files inside the closure
+    let filenames = Some(&["tests1.dat"][..]);
+    let fixtures = tree_construction::fixtures(filenames).expect("problem loading fixtures");
 
     group.bench_function("fixtures", |b| {
         b.iter(|| {
             for root in &fixtures {
                 for test in &root.tests {
-                    test.tokenize();
+                    let _ = test.parse().unwrap();
                 }
             }
         })

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -67,7 +67,7 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
 
     results.tests += 1;
 
-    let result = test.run();
+    let result = test.run().expect("problem running tree construction test");
     print_test_result(&result);
 
     // Check the document tree, which counts as a single assertion

--- a/tests/tree_construction.rs
+++ b/tests/tree_construction.rs
@@ -3,7 +3,33 @@ use lazy_static::lazy_static;
 use std::collections::HashSet;
 use test_case::test_case;
 
-const DISABLED_CASES: &[&str] = &[];
+const DISABLED_CASES: &[&str] = &[
+    "<a X>0<b>1<a Y>2",
+    "<!-----><font><div>hello<table>excite!<b>me!<th><i>please!</tr><!--X-->",
+    "<!DOCTYPE html><li>hello<li>world<ul>how<li>do</ul>you</body><!--do-->",
+    "<!DOCTYPE html><script> <!-- </script> --> </script> EOF",
+    "<p id=a><b><p id=b></b>TEST",
+    "<b id=a><p><b id=b></p></b>TEST",
+    "<font><p>hello<b>cruel</font>world",
+    "<DIV> abc <B> def <I> ghi <P> jkl </B>",
+    "<DIV> abc <B> def <I> ghi <P> jkl </B> mno",
+    "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I>",
+    "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I> pqr",
+    "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I> pqr </P>",
+    "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I> pqr </P> stu",
+    r#"<a href="blah">aba<table><a href="foo">br<tr><td></td></tr>x</table>aoe"#,
+    r#"<a href="blah">aba<table><tr><td><a href="foo">br</td></tr>x</table>aoe"#,
+    r#"<table><a href="blah">aba<tr><td><a href="foo">br</td></tr>x</table>aoe"#,
+    "<a href=a>aa<marquee>aa<a href=b>bb</marquee>aa",
+    "<table><tr><tr><td><td><span><th><span>X</table>",
+    "<textarea><p></textarea>",
+    "<ul><li></li><div><li></div><li><li><div><li><address><li><b><em></b><li></ul>",
+    "<ul><li><ul></li><li>a</li></ul></li></ul>",
+    "<p><b><div><marquee></p></b></div>X",
+    "<a><table><td><a><table></table><a></tr><a></table><b>X</b>C<a>Y",
+    "<wbr><strike><code></strike><code><strike></code>",
+    "<p><b><div><marquee></p></b></div>",
+];
 
 lazy_static! {
     static ref DISABLED: HashSet<String> = DISABLED_CASES
@@ -12,6 +38,7 @@ lazy_static! {
         .collect::<HashSet<_>>();
 }
 
+// See tests/data/html5lib-tests/tree-construction/ for other test files.
 #[test_case("tests1.dat")]
 fn tree_construction(filename: &str) {
     let fixture_file = fixture_from_filename(filename).expect("fixture");
@@ -19,10 +46,11 @@ fn tree_construction(filename: &str) {
     for test in fixture_file.tests {
         if DISABLED.contains(&test.data) {
             // Check that we don't panic
-            test.run();
+            let _ = test.parse().expect("problem parsing");
             continue;
         }
 
+        println!("tree construction: {}", test.data);
         test.assert_valid();
     }
 }


### PR DESCRIPTION
This PR
* Adds parsing test cases from `tests1.dat` to the CI run
* Adds a placeholder benchmark suite for tree construction (parsing)

On this branch, all tests pass:

![2023-10-17_17-42](https://github.com/gosub-browser/gosub-engine/assets/760949/a474ec3b-86e0-4950-8476-db9ca3dace55)

The current `parser_test` binary still works as before:

![2023-10-17_17-44](https://github.com/gosub-browser/gosub-engine/assets/760949/cc57ca48-0b54-478b-a29a-ef003e9d84ed)

To see the parser / tree construction tests in action, comment out one of the disabled cases in `tests/tree_construction.rs`:

![2023-10-17_17-39](https://github.com/gosub-browser/gosub-engine/assets/760949/93c1f477-9660-4491-a046-c684756a5699)

![2023-10-17_17-40](https://github.com/gosub-browser/gosub-engine/assets/760949/43c35a05-4cd1-4b76-8395-69205c659b7b)

To see the new benchmark suite, run:
```sh
$ cargo bench
```

![2023-10-17_17-35](https://github.com/gosub-browser/gosub-engine/assets/760949/d0b65150-1660-4dad-b840-61ec8036d3db)

Click on "fixtures" to see the detailed view:

![2023-10-17_17-37](https://github.com/gosub-browser/gosub-engine/assets/760949/fc1eb688-fa80-44d3-b853-47c6791dd208)

As with the tokenizer benchmark suite, these are not well-thought-out benchmarks and will eventually need to be replaced with better benchmark tests.
