### PR TITLE
Get some parser tests to pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -191,7 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -245,6 +245,12 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -305,6 +311,8 @@ dependencies = [
  "colored",
  "criterion",
  "derive_more",
+ "indexmap",
+ "itertools 0.11.0",
  "lazy_static",
  "phf",
  "regex",
@@ -325,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +352,16 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -356,6 +380,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,11 @@ ureq = "2.8.0"
 anyhow = "1.0.75"
 uuid = { version = "1.4.1", features = ["v4"] }
 colored = "2.0.4"
+indexmap = "2.0.2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+itertools = "0.11.0"
 test-case = "3.2.1"
 
 [features]

--- a/src/html5/node.rs
+++ b/src/html5/node.rs
@@ -3,9 +3,9 @@ use crate::html5::node::data::comment::CommentData;
 use crate::html5::node::data::document::DocumentData;
 use crate::html5::node::data::element::ElementData;
 use crate::html5::node::data::text::TextData;
+use crate::types::AttributeMap;
 use core::fmt::Debug;
 use derive_more::Display;
-use std::collections::HashMap;
 
 pub const HTML_NAMESPACE: &str = "http://www.w3.org/1999/xhtml";
 pub const MATHML_NAMESPACE: &str = "http://www.w3.org/1998/Math/MathML";
@@ -193,7 +193,7 @@ impl Node {
     pub fn new_element(
         document: &DocumentHandle,
         name: &str,
-        attributes: HashMap<String, String>,
+        attributes: AttributeMap,
         namespace: &str,
     ) -> Self {
         Node {
@@ -448,7 +448,7 @@ mod tests {
 
     #[test]
     fn new_element() {
-        let mut attributes = HashMap::new();
+        let mut attributes = AttributeMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let document = Document::shared();
         let node = Node::new_element(&document, "div", attributes.clone(), HTML_NAMESPACE);
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn is_special() {
-        let mut attributes = HashMap::new();
+        let mut attributes = AttributeMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let document = Document::shared();
         let node = Node::new_element(&document, "div", attributes, HTML_NAMESPACE);
@@ -513,7 +513,7 @@ mod tests {
         assert_eq!(node.type_of(), NodeType::Text);
         let node = Node::new_comment(&document, "test");
         assert_eq!(node.type_of(), NodeType::Comment);
-        let mut attributes = HashMap::new();
+        let mut attributes = AttributeMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let node = Node::new_element(&document, "div", attributes, HTML_NAMESPACE);
         assert_eq!(node.type_of(), NodeType::Element);
@@ -523,7 +523,7 @@ mod tests {
     fn special_html_elements() {
         let document = Document::shared();
         for element in SPECIAL_HTML_ELEMENTS.iter() {
-            let mut attributes = HashMap::new();
+            let mut attributes = AttributeMap::new();
             attributes.insert("id".to_string(), "test".to_string());
             let node = Node::new_element(&document, element, attributes, HTML_NAMESPACE);
             assert!(node.is_special());
@@ -534,7 +534,7 @@ mod tests {
     fn special_mathml_elements() {
         let document = Document::shared();
         for element in SPECIAL_MATHML_ELEMENTS.iter() {
-            let mut attributes = HashMap::new();
+            let mut attributes = AttributeMap::new();
             attributes.insert("id".to_string(), "test".to_string());
             let node = Node::new_element(&document, element, attributes, MATHML_NAMESPACE);
             assert!(node.is_special());
@@ -545,7 +545,7 @@ mod tests {
     fn special_svg_elements() {
         let document = Document::shared();
         for element in SPECIAL_SVG_ELEMENTS.iter() {
-            let mut attributes = HashMap::new();
+            let mut attributes = AttributeMap::new();
             attributes.insert("id".to_string(), "test".to_string());
             let node = Node::new_element(&document, element, attributes, SVG_NAMESPACE);
             assert!(node.is_special());
@@ -561,7 +561,7 @@ mod tests {
         assert_eq!(node.type_of(), NodeType::Text);
         let node = Node::new_comment(&document, "test");
         assert_eq!(node.type_of(), NodeType::Comment);
-        let mut attributes = HashMap::new();
+        let mut attributes = AttributeMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let node = Node::new_element(&document, "div", attributes, HTML_NAMESPACE);
         assert_eq!(node.type_of(), NodeType::Element);
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn contains_attribute() {
-        let mut attr = HashMap::new();
+        let mut attr = AttributeMap::new();
         attr.insert("x".to_string(), "value".to_string());
         let document = Document::shared();
         let node = Node::new_element(&document, "node", attr.clone(), HTML_NAMESPACE);
@@ -582,7 +582,7 @@ mod tests {
 
     #[test]
     fn insert_attribute() {
-        let attr = HashMap::new();
+        let attr = AttributeMap::new();
         let document = Document::shared();
         let mut node = Node::new_element(&document, "name", attr.clone(), HTML_NAMESPACE);
         let NodeData::Element(element) = &mut node.data else {
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn remove_attribute() {
-        let mut attr = HashMap::new();
+        let mut attr = AttributeMap::new();
         attr.insert("key".to_string(), "value".to_string());
         let document = Document::shared();
         let mut node = Node::new_element(&document, "name", attr.clone(), HTML_NAMESPACE);
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn get_attribute() {
-        let mut attr = HashMap::new();
+        let mut attr = AttributeMap::new();
         attr.insert("key".to_string(), "value".to_string());
         let document = Document::shared();
         let node = Node::new_element(&document, "name", attr.clone(), HTML_NAMESPACE);
@@ -619,7 +619,7 @@ mod tests {
 
     #[test]
     fn get_mut_attribute() {
-        let mut attr = HashMap::new();
+        let mut attr = AttributeMap::new();
         attr.insert("key".to_string(), "value".to_string());
         let document = Document::shared();
         let mut node = Node::new_element(&document, "name", attr.clone(), HTML_NAMESPACE);
@@ -633,7 +633,7 @@ mod tests {
 
     #[test]
     fn clear_attributes() {
-        let mut attr = HashMap::new();
+        let mut attr = AttributeMap::new();
         attr.insert("key".to_string(), "value".to_string());
         let document = Document::shared();
         let mut node = Node::new_element(&document, "name", attr.clone(), HTML_NAMESPACE);
@@ -646,7 +646,7 @@ mod tests {
 
     #[test]
     fn has_attributes() {
-        let attr = HashMap::new();
+        let attr = AttributeMap::new();
         let document = Document::shared();
         let mut node = Node::new_element(&document, "name", attr.clone(), HTML_NAMESPACE);
         let NodeData::Element(element) = &mut node.data else {

--- a/src/html5/node/arena.rs
+++ b/src/html5/node/arena.rs
@@ -80,12 +80,13 @@ mod tests {
     use super::*;
     use crate::html5::node::HTML_NAMESPACE;
     use crate::html5::parser::document::Document;
+    use crate::types::AttributeMap;
 
     #[test]
     fn register_node() {
         let mut doc = Document::shared();
 
-        let node = Node::new_element(&doc, "test", HashMap::new(), HTML_NAMESPACE);
+        let node = Node::new_element(&doc, "test", AttributeMap::new(), HTML_NAMESPACE);
         let mut document = doc.get_mut();
         let id = document.arena.register_node(node);
 
@@ -99,7 +100,7 @@ mod tests {
     fn register_node_twice() {
         let mut doc = Document::shared();
 
-        let node = Node::new_element(&doc, "test", HashMap::new(), HTML_NAMESPACE);
+        let node = Node::new_element(&doc, "test", AttributeMap::new(), HTML_NAMESPACE);
         let mut document = doc.get_mut();
         document.arena.register_node(node);
 
@@ -110,7 +111,7 @@ mod tests {
     #[test]
     fn get_node() {
         let mut doc = Document::shared();
-        let node = Node::new_element(&doc, "test", HashMap::new(), HTML_NAMESPACE);
+        let node = Node::new_element(&doc, "test", AttributeMap::new(), HTML_NAMESPACE);
 
         let mut document = doc.get_mut();
         let id = document.arena.register_node(node);
@@ -122,7 +123,7 @@ mod tests {
     #[test]
     fn get_node_mut() {
         let mut doc = Document::shared();
-        let node = Node::new_element(&doc, "test", HashMap::new(), HTML_NAMESPACE);
+        let node = Node::new_element(&doc, "test", AttributeMap::new(), HTML_NAMESPACE);
 
         let mut document = doc.get_mut();
 
@@ -136,8 +137,8 @@ mod tests {
     fn register_node_through_document() {
         let mut doc = Document::shared();
 
-        let parent = Node::new_element(&doc, "parent", HashMap::new(), HTML_NAMESPACE);
-        let child = Node::new_element(&doc, "child", HashMap::new(), HTML_NAMESPACE);
+        let parent = Node::new_element(&doc, "parent", AttributeMap::new(), HTML_NAMESPACE);
+        let child = Node::new_element(&doc, "child", AttributeMap::new(), HTML_NAMESPACE);
 
         let mut document = doc.get_mut();
         let parent_id = document.arena.register_node(parent);

--- a/src/html5/node/data/element.rs
+++ b/src/html5/node/data/element.rs
@@ -1,9 +1,9 @@
 use crate::html5::element_class::ElementClass;
 use crate::html5::node::NodeId;
 use crate::html5::parser::document::{Document, DocumentFragment, DocumentHandle};
+use crate::types::AttributeMap;
 use core::fmt::{Debug, Formatter};
-use std::collections::hash_map::Iter;
-use std::collections::HashMap;
+
 use std::fmt;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -14,7 +14,7 @@ pub(crate) struct ElementAttributes {
     /// Pointer to the document that the node associated with these attributes are tied to
     pub(crate) document: DocumentHandle,
     /// Key-value pair of all attributes
-    attributes: HashMap<String, String>,
+    attributes: AttributeMap,
 }
 
 /// This is a very thin wrapper around a HashMap.
@@ -26,14 +26,14 @@ impl ElementAttributes {
         Self {
             node_id,
             document,
-            attributes: HashMap::new(),
+            attributes: AttributeMap::new(),
         }
     }
 
     pub(crate) fn with_attributes(
         node_id: NodeId,
         document: DocumentHandle,
-        attributes: HashMap<String, String>,
+        attributes: AttributeMap,
     ) -> Self {
         Self {
             node_id,
@@ -78,19 +78,19 @@ impl ElementAttributes {
     }
 
     /// Returns an iterator over the attribute map.
-    pub(crate) fn iter(&self) -> Iter<'_, String, String> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
         self.attributes.iter()
     }
 
     /// Adds the given attributes to the attribute map.
-    pub(crate) fn copy_from(&mut self, attribute_map: HashMap<String, String>) {
+    pub(crate) fn copy_from(&mut self, attribute_map: AttributeMap) {
         for (key, value) in attribute_map.iter() {
             self.insert(key, value);
         }
     }
 
     /// Clones the internal map of attributes (NOT the attributes object itself)
-    pub(crate) fn clone_map(&self) -> HashMap<String, String> {
+    pub(crate) fn clone_map(&self) -> AttributeMap {
         self.attributes.clone()
     }
 }
@@ -138,7 +138,7 @@ impl ElementData {
         node_id: NodeId,
         document: DocumentHandle,
         name: &str,
-        attributes: HashMap<String, String>,
+        attributes: AttributeMap,
     ) -> Self {
         Self {
             node_id,

--- a/src/html5/parser/adoption_agency.rs
+++ b/src/html5/parser/adoption_agency.rs
@@ -1,7 +1,7 @@
 use crate::html5::node::{Node, NodeData, NodeId, HTML_NAMESPACE};
 use crate::html5::parser::{ActiveElement, Html5Parser, Scope};
 use crate::html5::tokenizer::token::Token;
-use std::collections::HashMap;
+use crate::types::AttributeMap;
 
 const ADOPTION_AGENCY_OUTER_LOOP_DEPTH: usize = 8;
 const ADOPTION_AGENCY_INNER_LOOP_DEPTH: usize = 3;
@@ -169,7 +169,7 @@ impl<'stream> Html5Parser<'stream> {
                 // replace the old node with the new replacement node
                 let node_attributes = match node.data {
                     NodeData::Element(element) => element.attributes.clone_map(),
-                    _ => HashMap::new(),
+                    _ => AttributeMap::new(),
                 };
 
                 let replacement_node = Node::new_element(
@@ -330,7 +330,8 @@ mod test {
 
     macro_rules! node_create {
         ($self:expr, $name:expr) => {{
-            let node = Node::new_element(&$self.document, $name, HashMap::new(), HTML_NAMESPACE);
+            let node =
+                Node::new_element(&$self.document, $name, AttributeMap::new(), HTML_NAMESPACE);
             let node_id = $self
                 .document
                 .get_mut()

--- a/src/html5/parser/document.rs
+++ b/src/html5/parser/document.rs
@@ -483,7 +483,7 @@ impl DocumentHandle {
 mod tests {
     use crate::html5::node::HTML_NAMESPACE;
     use crate::html5::parser::{Document, Node, NodeData, NodeId};
-    use std::collections::HashMap;
+    use crate::types::AttributeMap;
 
     #[test]
     fn relocate() {
@@ -491,11 +491,11 @@ mod tests {
         let document_clone = Document::clone(&document);
         document.get_mut().create_root(&document_clone);
 
-        let parent = Node::new_element(&document, "parent", HashMap::new(), HTML_NAMESPACE);
-        let node1 = Node::new_element(&document, "div1", HashMap::new(), HTML_NAMESPACE);
-        let node2 = Node::new_element(&document, "div2", HashMap::new(), HTML_NAMESPACE);
-        let node3 = Node::new_element(&document, "div3", HashMap::new(), HTML_NAMESPACE);
-        let node3_1 = Node::new_element(&document, "div3_1", HashMap::new(), HTML_NAMESPACE);
+        let parent = Node::new_element(&document, "parent", AttributeMap::new(), HTML_NAMESPACE);
+        let node1 = Node::new_element(&document, "div1", AttributeMap::new(), HTML_NAMESPACE);
+        let node2 = Node::new_element(&document, "div2", AttributeMap::new(), HTML_NAMESPACE);
+        let node3 = Node::new_element(&document, "div3", AttributeMap::new(), HTML_NAMESPACE);
+        let node3_1 = Node::new_element(&document, "div3_1", AttributeMap::new(), HTML_NAMESPACE);
 
         let parent_id = document.get_mut().add_node(parent, NodeId::from(0), None);
         let node1_id = document.get_mut().add_node(node1, parent_id, None);
@@ -541,7 +541,7 @@ mod tests {
 
     #[test]
     fn set_named_id_to_element() {
-        let attributes = HashMap::new();
+        let attributes = AttributeMap::new();
         let mut document = Document::shared();
         let node = Node::new_element(&document, "div", attributes.clone(), HTML_NAMESPACE);
         let node_id = NodeId::from(0);
@@ -602,8 +602,7 @@ mod tests {
 
     #[test]
     fn duplicate_named_id_elements() {
-        let attributes = HashMap::new();
-
+        let attributes = AttributeMap::new();
         let mut document = Document::shared();
 
         let mut node1 = Node::new_element(&document, "div", attributes.clone(), HTML_NAMESPACE);
@@ -651,8 +650,8 @@ mod tests {
         let document_clone = Document::clone(&document);
         document.get_mut().create_root(&document_clone);
 
-        let node1 = Node::new_element(&document, "div", HashMap::new(), HTML_NAMESPACE);
-        let node2 = Node::new_element(&document, "div", HashMap::new(), HTML_NAMESPACE);
+        let node1 = Node::new_element(&document, "div", AttributeMap::new(), HTML_NAMESPACE);
+        let node2 = Node::new_element(&document, "div", AttributeMap::new(), HTML_NAMESPACE);
 
         document.get_mut().add_node(node1, NodeId::from(0), None);
         document.get_mut().add_node(node2, NodeId::from(0), None);

--- a/src/html5/parser/lib.rs
+++ b/src/html5/parser/lib.rs
@@ -1,1 +1,0 @@
-pub mod nodes;

--- a/src/html5/tokenizer.rs
+++ b/src/html5/tokenizer.rs
@@ -10,9 +10,8 @@ use crate::html5::input_stream::SeekMode::SeekCur;
 use crate::html5::input_stream::{InputStream, Position};
 use crate::html5::tokenizer::state::State;
 use crate::html5::tokenizer::token::Token;
-use crate::types::{Error, Result};
+use crate::types::{AttributeMap, Error, Result};
 use std::cell::{Ref, RefCell};
-use std::collections::HashMap;
 use std::rc::Rc;
 
 /// Constants that are not directly captured as visible chars
@@ -37,7 +36,7 @@ pub struct Tokenizer<'stream> {
     /// Current attribute value that we need to store temporary in case we are parsing attributes
     pub current_attr_value: String,
     /// Current attributes
-    pub current_attrs: HashMap<String, String>,
+    pub current_attrs: AttributeMap,
     /// Token that is currently in the making (if any)
     pub current_token: Option<Token>,
     /// Temporary buffer
@@ -82,7 +81,7 @@ impl<'stream> Tokenizer<'stream> {
             token_queue: vec![],
             current_attr_name: String::new(),
             current_attr_value: String::new(),
-            current_attrs: HashMap::new(),
+            current_attrs: AttributeMap::new(),
             temporary_buffer: String::new(),
             error_logger,
         };
@@ -229,7 +228,7 @@ impl<'stream> Tokenizer<'stream> {
                             self.current_token = Some(Token::StartTagToken {
                                 name: "".into(),
                                 is_self_closing: false,
-                                attributes: HashMap::new(),
+                                attributes: AttributeMap::new(),
                             });
                             self.stream.unread();
                             self.state = State::TagNameState;
@@ -260,7 +259,7 @@ impl<'stream> Tokenizer<'stream> {
                             self.current_token = Some(Token::EndTagToken {
                                 name: "".into(),
                                 is_self_closing: false,
-                                attributes: HashMap::new(),
+                                attributes: AttributeMap::new(),
                             });
                             self.stream.unread();
                             self.state = State::TagNameState;
@@ -329,7 +328,7 @@ impl<'stream> Tokenizer<'stream> {
                             self.current_token = Some(Token::EndTagToken {
                                 name: "".into(),
                                 is_self_closing: false,
-                                attributes: HashMap::new(),
+                                attributes: AttributeMap::new(),
                             });
                             self.stream.unread();
                             self.state = State::RcDataEndTagNameState;
@@ -425,7 +424,7 @@ impl<'stream> Tokenizer<'stream> {
                             self.current_token = Some(Token::EndTagToken {
                                 name: "".into(),
                                 is_self_closing: false,
-                                attributes: HashMap::new(),
+                                attributes: AttributeMap::new(),
                             });
                             self.stream.unread();
                             self.state = State::RawTextEndTagNameState;
@@ -526,7 +525,7 @@ impl<'stream> Tokenizer<'stream> {
                             self.current_token = Some(Token::EndTagToken {
                                 name: "".into(),
                                 is_self_closing: false,
-                                attributes: HashMap::new(),
+                                attributes: AttributeMap::new(),
                             });
                             self.stream.unread();
                             self.state = State::ScriptDataEndTagNameState;
@@ -732,7 +731,7 @@ impl<'stream> Tokenizer<'stream> {
                             self.current_token = Some(Token::EndTagToken {
                                 name: "".into(),
                                 is_self_closing: false,
-                                attributes: HashMap::new(),
+                                attributes: AttributeMap::new(),
                             });
 
                             self.stream.unread();
@@ -2296,7 +2295,7 @@ impl<'stream> Tokenizer<'stream> {
                 for (key, value) in &self.current_attrs {
                     attributes.insert(key.clone(), value.clone());
                 }
-                self.current_attrs = HashMap::new();
+                self.current_attrs = AttributeMap::new();
             }
             _ => {}
         }

--- a/src/html5/tokenizer/token.rs
+++ b/src/html5/tokenizer/token.rs
@@ -1,5 +1,4 @@
-use crate::html5::tokenizer::CHAR_NUL;
-use std::collections::HashMap;
+use crate::{html5::tokenizer::CHAR_NUL, types::AttributeMap};
 
 /// The different tokens types that can be emitted by the tokenizer
 #[derive(Debug, PartialEq)]
@@ -19,7 +18,7 @@ pub struct Attribute {
 }
 
 /// The different token structures that can be emitted by the tokenizer
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     DocTypeToken {
         name: Option<String>,
@@ -30,12 +29,12 @@ pub enum Token {
     StartTagToken {
         name: String,
         is_self_closing: bool,
-        attributes: HashMap<String, String>,
+        attributes: AttributeMap,
     },
     EndTagToken {
         name: String,
         is_self_closing: bool,
-        attributes: HashMap<String, String>,
+        attributes: AttributeMap,
     },
     CommentToken {
         value: String,
@@ -226,11 +225,11 @@ mod tests {
         let token = Token::StartTagToken {
             name: "html".to_string(),
             is_self_closing: false,
-            attributes: HashMap::new(),
+            attributes: AttributeMap::new(),
         };
         assert_eq!(format!("{}", token), "<html>");
 
-        let mut attributes = HashMap::new();
+        let mut attributes = AttributeMap::new();
         attributes.insert("foo".to_string(), "bar".to_string());
 
         let token = Token::StartTagToken {
@@ -243,7 +242,7 @@ mod tests {
         let token = Token::StartTagToken {
             name: "br".to_string(),
             is_self_closing: true,
-            attributes: HashMap::new(),
+            attributes: AttributeMap::new(),
         };
         assert_eq!(format!("{}", token), "<br />");
     }
@@ -253,7 +252,7 @@ mod tests {
         let token = Token::EndTagToken {
             name: "html".to_string(),
             is_self_closing: false,
-            attributes: HashMap::new(),
+            attributes: AttributeMap::new(),
         };
         assert_eq!(format!("{}", token), "</html>");
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,4 +1,89 @@
+use crate::html5::{
+    node::{NodeData, NodeId},
+    parser::document::{Document, DocumentHandle},
+};
+use std::fmt::Display;
+
 pub mod tokenizer;
 pub mod tree_construction;
 
 pub const FIXTURE_ROOT: &str = "./tests/data/html5lib-tests";
+
+/// Render a document handle in the format used in the tree construction tests under
+/// ./tests/data/html5lib-tests/tree-construction/.
+pub struct TreeConstructionFormat(DocumentHandle);
+
+impl Display for TreeConstructionFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn print_node(
+            f: &mut std::fmt::Formatter<'_>,
+            node_id: NodeId,
+            document_offset_id: isize,
+            indent: isize,
+            doc: &Document,
+        ) -> isize {
+            let mut next_expected_idx = document_offset_id;
+            let node = doc.get_node_by_id(node_id).unwrap();
+
+            match &node.data {
+                NodeData::Document(..) => {}
+
+                NodeData::Element(element) => {
+                    writeln!(
+                        f,
+                        "|{}<{}>",
+                        " ".repeat(indent as usize * 2 + 1),
+                        element.name()
+                    )
+                    .unwrap();
+
+                    // Check attributes if any
+                    for (name, value) in element.attributes.iter() {
+                        writeln!(
+                            f,
+                            "|{}{name}=\"{value}\"",
+                            " ".repeat((indent as usize * 2) + 3),
+                        )
+                        .unwrap();
+                    }
+                }
+
+                NodeData::Text(text) => {
+                    writeln!(
+                        f,
+                        "|{}\"{}\"",
+                        " ".repeat(indent as usize * 2 + 1),
+                        text.value()
+                    )
+                    .unwrap();
+                }
+
+                NodeData::Comment(comment) => {
+                    writeln!(
+                        f,
+                        "|{}<!-- {} -->\n",
+                        " ".repeat(indent as usize * 2 + 1),
+                        comment.value()
+                    )
+                    .unwrap();
+                }
+            }
+
+            for &child_id in &node.children {
+                next_expected_idx = print_node(f, child_id, document_offset_id, indent + 1, doc);
+            }
+
+            next_expected_idx
+        }
+
+        print_node(f, NodeId::root(), 0, -1, &self.0.get());
+
+        Ok(())
+    }
+}
+
+impl DocumentHandle {
+    pub fn tree_construction_format(&self) -> TreeConstructionFormat {
+        TreeConstructionFormat(Document::clone(self))
+    }
+}

--- a/src/testing/tokenizer.rs
+++ b/src/testing/tokenizer.rs
@@ -1,19 +1,22 @@
 use super::FIXTURE_ROOT;
-use crate::html5::{
-    error_logger::ErrorLogger,
-    input_stream::InputStream,
-    tokenizer::{
-        state::State as TokenState,
-        token::{Attribute, Token, TokenType},
-        {Options, Tokenizer},
-    },
-};
 use crate::types::Result;
+use crate::{
+    html5::{
+        error_logger::ErrorLogger,
+        input_stream::InputStream,
+        tokenizer::{
+            state::State as TokenState,
+            token::{Attribute, Token, TokenType},
+            {Options, Tokenizer},
+        },
+    },
+    types::AttributeMap,
+};
 use lazy_static::lazy_static;
 use regex::{Captures, Regex};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::{cell::RefCell, rc::Rc};
 use std::{
     fs,
@@ -225,7 +228,7 @@ impl Test {
         &self,
         expected: &[Value],
         name: &str,
-        attributes: HashMap<String, String>,
+        attributes: AttributeMap,
         is_self_closing: bool,
     ) {
         let expected_name = expected.get(1).and_then(|v| v.as_str()).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use thiserror::Error;
 
 /// Generic error types that can be returned from the library.
@@ -21,3 +22,6 @@ pub enum Error {
 
 /// Result that can be returned which holds either T or an Error
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Element attributes
+pub type AttributeMap = IndexMap<String, String>;

--- a/tests/tree_construction.rs
+++ b/tests/tree_construction.rs
@@ -25,8 +25,7 @@ const DISABLED_CASES: &[&str] = &[
     "<!DOCTYPE html><script></script>  <title>x</title>  </head>",
     "<!DOCTYPE html><html><body><html id=x>",
     r#"<!DOCTYPE html>X</body><html id="x">"#,
-    "<!DOCTYPE html>X</html>",
-    "<!DOCTYPE html>X<p/x/y/z>",
+    "<!DOCTYPE html>X</html>", // Test formatting issue?
     "<!DOCTYPE <!DOCTYPE HTML>><!--<!--x-->-->",
     "<!doctype html><div><form></form><div></div></div>",
     // tests3.dat


### PR DESCRIPTION
The main point of this PR was to get some additional parser tests to pass:

![2023-10-19_21-11](https://github.com/gosub-browser/gosub-engine/assets/760949/0ac5fe17-2917-47c1-92c7-c2d6fcea2da8)

This PR:
* Gets some parser tests to pass
* Uses an index map to preserve order for element attributes, but hides it behind an `AttributeMap` type alias
* Adds the ability to render a document in the format used in the tree construction tests

I assume order is not important when interpreting attributes in an element.  But in order to reliably reproduce the printed tree that is used in the tree construction tests, we can't use `HashMap`, which randomizes the order of the keys.  Instead we use `IndexMap`, which preserves insertion order.  In order not to create too much of a dependency on the `indexmap` library in case we want to replace it in the future, an `AttributeMap` type alias has been used in the code in place of `IndexMap`.
