### PR TITLE
fix some test

### DIFF
--- a/src/html5/parser.rs
+++ b/src/html5/parser.rs
@@ -1212,7 +1212,7 @@ impl<'stream> Html5Parser<'stream> {
                         Token::EndTagToken { name, .. } if name == "optgroup" => {
                             if current_node!(self).name == "option"
                                 && self.open_elements.len() > 1
-                                && open_elements_get!(self, self.open_elements.len() - 1).name
+                                && open_elements_get!(self, self.open_elements.len() - 2).name
                                     == "optgroup"
                             {
                                 self.open_elements.pop();
@@ -2251,7 +2251,12 @@ impl<'stream> Html5Parser<'stream> {
 
                     if ["dd", "dt"].contains(&tag.as_str()) {
                         self.generate_implied_end_tags(Some(tag.as_str()), false);
-                        self.open_elements.pop();
+
+                        if current_node!(self).name != tag {
+                            self.parse_error("{tag} tag not at top of stack");
+                        }
+
+                        self.pop_until(tag.as_str());
                         break;
                     }
 

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -392,7 +392,7 @@ pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
                 || !current_test.errors.is_empty()
                 || !current_test.document.is_empty()
             {
-                current_test.data = current_test.data.trim_end_matches("\n").to_string();
+                current_test.data = current_test.data.trim_end_matches('\n').to_string();
                 tests.push(current_test);
                 current_test = Test {
                     file_path: path.to_str().unwrap().to_string(),
@@ -414,7 +414,7 @@ pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
             match sec {
                 "data" => {
                     if !current_test.data.is_empty() {
-                        current_test.data.push_str("\n");
+                        current_test.data.push('\n');
                     }
                     current_test.data.push_str(&line);
                 }
@@ -430,8 +430,8 @@ pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
                 }
                 "document" => {
                     let length = current_test.document.len();
-                    if length > 1 && !line.starts_with("|") && line != "" {
-                        current_test.document[length - 1].push_str("\n");
+                    if length > 1 && !line.starts_with('|') && !line.is_empty() {
+                        current_test.document[length - 1].push('\n');
                         current_test.document[length - 1].push_str(&line);
                     } else {
                         current_test.document.push(line);
@@ -448,7 +448,7 @@ pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
         || !current_test.errors.is_empty()
         || !current_test.document.is_empty()
     {
-        current_test.data = current_test.data.trim_end_matches("\n").to_string();
+        current_test.data = current_test.data.trim_end_matches('\n').to_string();
         tests.push(current_test);
     }
 

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -392,7 +392,7 @@ pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
                 || !current_test.errors.is_empty()
                 || !current_test.document.is_empty()
             {
-                current_test.data = current_test.data.trim_end_matches('\n').to_string();
+                current_test.data = current_test.data.strip_suffix('\n').unwrap().to_string();
                 tests.push(current_test);
                 current_test = Test {
                     file_path: path.to_str().unwrap().to_string(),
@@ -413,10 +413,8 @@ pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
         } else if let Some(sec) = section {
             match sec {
                 "data" => {
-                    if !current_test.data.is_empty() {
-                        current_test.data.push('\n');
-                    }
                     current_test.data.push_str(&line);
+                    current_test.data.push('\n');
                 }
                 "errors" => {
                     let re = Regex::new(r"\((?P<line>\d+),(?P<col>\d+)\): (?P<code>.+)").unwrap();
@@ -448,7 +446,7 @@ pub fn fixture_from_path(path: &PathBuf) -> Result<FixtureFile> {
         || !current_test.errors.is_empty()
         || !current_test.document.is_empty()
     {
-        current_test.data = current_test.data.trim_end_matches('\n').to_string();
+        current_test.data = current_test.data.strip_suffix('\n').unwrap().to_string();
         tests.push(current_test);
     }
 


### PR DESCRIPTION
found some test case failed in tree_constructions for tests3.dat. this is correctly behavior, because current for tag `<pre>` and `<textarea>` not implement ignore next `LF` token.