### PR TITLE
Bugfix: deal with some bugs in parsing some of the other .dat files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL=/usr/bin/env bash -O globstar
 
 all: help
 
-test: test_unit test_clippy test_fmt ## Runs tests
+test: test_commands test_unit test_clippy test_fmt ## Runs tests
 
 bench:
 	cargo bench
@@ -21,7 +21,7 @@ fix:
 test_unit:
 	source test-utils.sh ;\
 	section "Cargo test" ;\
-	cargo test
+	cargo test --features debug_parser
 
 test_clippy:
 	source test-utils.sh ;\
@@ -32,6 +32,10 @@ test_fmt:
 	source test-utils.sh ;\
 	section "Cargo fmt" ;\
 	cargo fmt -- --check
+
+test_commands:
+	cargo run --bin html5-parser-test >/dev/null
+	cargo run --bin parser_test >/dev/null
 
 help: ## Display available commands
 	echo "Available make commands:"

--- a/src/bin/html5-parser-test.rs
+++ b/src/bin/html5-parser-test.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
     let mut failed = 0;
 
     for file in files.iter() {
-        let fixture = fixture_from_filename(file.as_str())?;
+        let fixture = fixture_from_filename(file)?;
         print!("Test: ({:3}) {} [", fixture.tests.len(), file);
         let _ = std::io::stdout().flush();
 

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -1,6 +1,6 @@
 mod parser;
 
-use self::parser::{ErrorSpec, ScriptMode, TestSpec};
+use self::parser::{ErrorSpec, ScriptMode, TestSpec, QUOTED_DOUBLE_NEWLINE};
 use super::FIXTURE_ROOT;
 use crate::html5::node::{HTML_NAMESPACE, MATHML_NAMESPACE, SVG_NAMESPACE};
 use crate::{
@@ -436,7 +436,9 @@ pub fn fixture_from_filename(filename: &str) -> Result<FixtureFile> {
 // Split into an array of lines.  Combine lines in cases where a subsequent line does not
 // have a "|" prefix using an "\n" delimiter.  Otherwise strip "\n" from lines.
 fn document(s: &str) -> Vec<String> {
-    s.split('|')
+    let mut document = s
+        .replace(QUOTED_DOUBLE_NEWLINE, "\"\n\n\"")
+        .split('|')
         .skip(1)
         .filter_map(|l| {
             if l.is_empty() {
@@ -445,7 +447,11 @@ fn document(s: &str) -> Vec<String> {
                 Some(format!("|{}", l.trim_end()))
             }
         })
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+
+    // TODO: drop the following line
+    document.push("".into());
+    document
 }
 
 /// Read a given test file and extract all test data


### PR DESCRIPTION
When reading through Slack, I noticed that there is a new `html5-parser-test` binary under `src/bin`. When I tried to run it after merging my latest PR, I saw that it exits early because the new tree construction test parsing code is unable to handle several corner cases.  This PR fixes that handling.

While we're here, let's add `--features debug_logger` to the test run, so that we can catch any compilation issues when this feature is enabled.  Otherwise Rust will ignore the code behind the feature, and you might have broken the feature without knowing it.

```sh
$ cargo run --color=always --package gosub-engine --bin html5-parser-test
```

Before this PR:

![2023-10-27_21-32](https://github.com/gosub-browser/gosub-engine/assets/760949/541de02c-9051-4259-b872-a08a2da1e620)

After this PR:

![2023-10-27_21-31](https://github.com/gosub-browser/gosub-engine/assets/760949/dada5a3c-6992-4fbc-8ed0-76e1ce0825c3)
