### PR TITLE
Handle all script modes in the tree construction tests

### DIFF
--- a/benches/tree_construction.rs
+++ b/benches/tree_construction.rs
@@ -13,10 +13,12 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             for root in &fixtures {
                 for test in &root.tests {
-                    let _ = test.parse().unwrap();
+                    for &scripting_enabled in test.script_modes() {
+                        let _ = test.parse(scripting_enabled).unwrap();
+                    }
                 }
             }
-        })
+        });
     });
 
     group.finish();

--- a/src/bin/html5-parser-test.rs
+++ b/src/bin/html5-parser-test.rs
@@ -19,16 +19,18 @@ fn main() -> Result<()> {
 
         // Run tests
         for test in fixture.tests {
-            let result = test.run().expect("problem running tree construction test");
+            let results = test.run().expect("problem running tree construction test");
 
-            total += 1;
-            if result.success() {
-                print!(".");
-            } else {
-                print!("X");
-                failed += 1;
+            for result in results {
+                total += 1;
+                if result.success() {
+                    print!(".");
+                } else {
+                    print!("X");
+                    failed += 1;
+                }
+                let _ = std::io::stdout().flush();
             }
-            let _ = std::io::stdout().flush();
         }
 
         println!("]");

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -137,20 +137,25 @@ impl Test {
     }
 
     /// Runs the test and returns the result
-    pub fn run(&self) -> Result<TestResult> {
-        let (actual_document, actual_errors) = self.parse()?;
-        let root = self.match_document_tree(&actual_document.get());
+    pub fn run(&self) -> Result<Vec<TestResult>> {
+        let mut results = vec![];
 
-        Ok(TestResult {
-            root,
-            actual_document,
-            actual_errors,
-        })
+        for &scripting_enabled in self.script_modes() {
+            let (actual_document, actual_errors) = self.parse(scripting_enabled)?;
+            let root = self.match_document_tree(&actual_document.get());
+            results.push(TestResult {
+                root,
+                actual_document,
+                actual_errors,
+            });
+        }
+
+        Ok(results)
     }
 
     /// Verifies that the tree construction code obtains the right result
     pub fn assert_valid(&self) {
-        let result = self.run().expect("failed to parse");
+        let results = self.run().expect("failed to parse");
 
         fn assert_tree(tree: &SubtreeResult) {
             match &tree.node {
@@ -192,22 +197,19 @@ impl Test {
             tree.children.iter().for_each(assert_tree);
         }
 
-        assert_tree(&result.root);
-        assert!(result.success(), "invalid tree-construction result");
+        for result in results {
+            assert_tree(&result.root);
+            assert!(result.success(), "invalid tree-construction result");
+        }
     }
 
     /// Run the parser and return the document and errors
-    pub fn parse(&self) -> Result<(DocumentHandle, Vec<ParseError>)> {
+    pub fn parse(&self, scripting_enabled: bool) -> Result<(DocumentHandle, Vec<ParseError>)> {
         // Do the actual parsing
         let mut is = InputStream::new();
         is.read_from_str(self.data(), None);
         let mut parser = Html5Parser::new(&mut is);
-
-        let enabled = matches!(
-            self.spec.script_mode,
-            ScriptMode::ScriptOn | ScriptMode::Both
-        );
-        parser.enabled_scripting(enabled);
+        parser.enabled_scripting(scripting_enabled);
 
         let document = Document::shared();
         let parse_errors = parser.parse(Document::clone(&document))?;
@@ -422,6 +424,14 @@ impl Test {
         ErrorResult::PositionFailure {
             expected: expected.to_owned(),
             actual: actual.to_owned(),
+        }
+    }
+
+    pub fn script_modes(&self) -> &[bool] {
+        match self.spec.script_mode {
+            ScriptMode::ScriptOff => &[false],
+            ScriptMode::ScriptOn => &[true],
+            ScriptMode::Both => &[false, true],
         }
     }
 }

--- a/tests/tree_construction.rs
+++ b/tests/tree_construction.rs
@@ -118,8 +118,10 @@ fn tree_construction(filename: &str) {
 
     for test in fixture_file.tests {
         if DISABLED.contains(test.data()) {
-            // Check that we don't panic
-            let _ = test.parse().expect("problem parsing");
+            for &scripting_enabled in test.script_modes() {
+                // Check that we don't panic
+                let _ = test.parse(scripting_enabled).expect("problem parsing");
+            }
             continue;
         }
 


### PR DESCRIPTION
This PR adds support for testing both `#script-on` and `#script-off` when these flags are present or absent in a tree construction test spec.

In this case, neither `#script-on` nor `#script-off` is present, so [both modes](https://github.com/html5lib/html5lib-tests/tree/master/tree-construction#tree-construction-tests) should be used for the test:

```
#data
FOO<!-- BAR --!>BAZ
#errors
(1,3): expected-doctype-but-got-chars
(1,15): unexpected-bang-after-double-dash-in-comment
#new-errors
(1:16) incorrectly-closed-comment
#document
| <html>
|   <head>
|   <body>
|     "FOO"
|     <!--  BAR  -->
|     "BAZ"
```