### PR TITLE
Begin to revisit tokenization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ harness = false
 [dependencies]
 phf = { version = "0.11.2", features = ["macros"] }
 derive_more = "0.99"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 regex = "1"

--- a/benches/tokenizer.rs
+++ b/benches/tokenizer.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use gosub_engine::testing::tokenizer;
+use gosub_engine::testing::tokenizer::{self, FixtureFile};
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Criterion can report inconsistent results from run to run in some cases.  We attempt to
@@ -14,7 +14,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("fixtures", |b| {
         b.iter(|| {
             for root in &fixtures {
-                for test in &root.tests {
+                let tests = match root {
+                    FixtureFile::Tests { tests } => tests,
+                    FixtureFile::XmlTests { tests } => tests,
+                };
+
+                for test in tests {
                     test.tokenize();
                 }
             }

--- a/src/html5/parser/helper.rs
+++ b/src/html5/parser/helper.rs
@@ -308,7 +308,7 @@ impl<'stream> Html5Parser<'stream> {
     pub fn adoption_agency_algorithm(&mut self, token: &Token) {
         // step 1
         let subject = match token {
-            Token::StartTagToken { name, .. } | Token::EndTagToken { name, .. } => name,
+            Token::StartTag { name, .. } | Token::EndTag { name, .. } => name,
             _ => panic!("un reached"),
         };
         let current_node = current_node!(self);

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -1,8 +1,7 @@
+use gosub_engine::testing::tokenizer::{self, FixtureFile};
 use lazy_static::lazy_static;
 use std::collections::HashSet;
 use test_case::test_case;
-
-use gosub_engine::testing::tokenizer;
 
 const DISABLED_CASES: &[&str] = &[
     // TODO: Handle UTF-16 high and low private surrogate characters
@@ -53,7 +52,12 @@ lazy_static! {
 fn tokenization(filename: &str) {
     let root = tokenizer::fixture_from_filename(filename).unwrap();
 
-    for test in root.tests {
+    let tests = match root {
+        FixtureFile::Tests { tests } => tests,
+        FixtureFile::XmlTests { tests } => tests,
+    };
+
+    for test in tests {
         if DISABLED.contains(&test.description) {
             // Check that we don't panic
             test.tokenize();


### PR DESCRIPTION
This PR begins to revisit tokenization:
* Further implement deserialization of the tokenization tests, and add unit tests
* Drop the `TokenTrait` trait, `TokenType` enum, and `type_of` method, as `matches!` and `match` can be used here instead
* Simplify assertions in pass/fail CI tests by using partial equality to compare tokens
* Remove stutter from the names of token variants
