### PR TITLE
Continue to revisit the tokenization code

### DIFF
--- a/src/html5/tokenizer.rs
+++ b/src/html5/tokenizer.rs
@@ -169,7 +169,7 @@ impl<'stream> Tokenizer<'stream> {
                 State::RAWTEXT => {
                     let c = self.read_char();
                     match c {
-                        Ch('<') => self.state = State::RawTextLessThanSign,
+                        Ch('<') => self.state = State::RAWTEXTLessThanSign,
                         Ch(CHAR_NUL) => {
                             self.consume(CHAR_REPLACEMENT);
                             self.parse_error(ParserError::UnexpectedNullCharacter);
@@ -398,12 +398,12 @@ impl<'stream> Tokenizer<'stream> {
                         self.transition_to(State::RCDATA);
                     }
                 }
-                State::RawTextLessThanSign => {
+                State::RAWTEXTLessThanSign => {
                     let c = self.read_char();
                     match c {
                         Ch('/') => {
                             self.temporary_buffer.clear();
-                            self.state = State::RawTextEndTagOpen;
+                            self.state = State::RAWTEXTEndTagOpen;
                         }
                         _ => {
                             self.consume('<');
@@ -412,7 +412,7 @@ impl<'stream> Tokenizer<'stream> {
                         }
                     }
                 }
-                State::RawTextEndTagOpen => {
+                State::RAWTEXTEndTagOpen => {
                     let c = self.read_char();
                     match c {
                         Ch(ch) if ch.is_ascii_alphabetic() => {
@@ -421,7 +421,7 @@ impl<'stream> Tokenizer<'stream> {
                                 is_self_closing: false,
                             });
                             self.stream.unread();
-                            self.state = State::RawTextEndTagName;
+                            self.state = State::RAWTEXTEndTagName;
                         }
                         _ => {
                             self.consume('<');
@@ -431,7 +431,7 @@ impl<'stream> Tokenizer<'stream> {
                         }
                     }
                 }
-                State::RawTextEndTagName => {
+                State::RAWTEXTEndTagName => {
                     let c = self.read_char();
 
                     // we use this flag because a lot of matches will actually do the same thing
@@ -1189,7 +1189,7 @@ impl<'stream> Tokenizer<'stream> {
 
                     if self.stream.look_ahead_slice(7).to_uppercase() == "DOCTYPE" {
                         self.stream.seek(SeekCur, 7);
-                        self.state = State::DocType;
+                        self.state = State::DOCTYPE;
                         continue;
                     }
 
@@ -1398,15 +1398,15 @@ impl<'stream> Tokenizer<'stream> {
                         }
                     }
                 }
-                State::DocType => {
+                State::DOCTYPE => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
-                            self.state = State::BeforeDocTypeName
+                            self.state = State::BeforeDOCTYPEName
                         }
                         Ch('>') => {
                             self.stream.unread();
-                            self.state = State::BeforeDocTypeName;
+                            self.state = State::BeforeDOCTYPEName;
                         }
                         Eof => {
                             self.parse_error(ParserError::EofInDoctype);
@@ -1423,11 +1423,11 @@ impl<'stream> Tokenizer<'stream> {
                         _ => {
                             self.parse_error(ParserError::MissingWhitespaceBeforeDoctypeName);
                             self.stream.unread();
-                            self.state = State::BeforeDocTypeName;
+                            self.state = State::BeforeDOCTYPEName;
                         }
                     }
                 }
-                State::BeforeDocTypeName => {
+                State::BeforeDOCTYPEName => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
@@ -1442,7 +1442,7 @@ impl<'stream> Tokenizer<'stream> {
                             });
 
                             self.add_to_token_name(to_lowercase!(ch));
-                            self.state = State::DocTypeName;
+                            self.state = State::DOCTYPEName;
                         }
                         Ch(CHAR_NUL) => {
                             self.parse_error(ParserError::UnexpectedNullCharacter);
@@ -1454,7 +1454,7 @@ impl<'stream> Tokenizer<'stream> {
                             });
 
                             self.add_to_token_name(CHAR_REPLACEMENT);
-                            self.state = State::DocTypeName;
+                            self.state = State::DOCTYPEName;
                         }
                         Ch('>') => {
                             self.parse_error(ParserError::MissingDoctypeName);
@@ -1489,15 +1489,15 @@ impl<'stream> Tokenizer<'stream> {
                             });
 
                             self.add_to_token_name(c.into());
-                            self.state = State::DocTypeName;
+                            self.state = State::DOCTYPEName;
                         }
                     }
                 }
-                State::DocTypeName => {
+                State::DOCTYPEName => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
-                            self.state = State::AfterDocTypeName
+                            self.state = State::AfterDOCTYPEName
                         }
                         Ch('>') => {
                             self.emit_current_token();
@@ -1517,7 +1517,7 @@ impl<'stream> Tokenizer<'stream> {
                         _ => self.add_to_token_name(c.into()),
                     }
                 }
-                State::AfterDocTypeName => {
+                State::AfterDOCTYPEName => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
@@ -1537,12 +1537,12 @@ impl<'stream> Tokenizer<'stream> {
                             self.stream.unread();
                             if self.stream.look_ahead_slice(6).to_uppercase() == "PUBLIC" {
                                 self.stream.seek(SeekCur, 6);
-                                self.state = State::AfterDocTypePublicKeyword;
+                                self.state = State::AfterDOCTYPEPublicKeyword;
                                 continue;
                             }
                             if self.stream.look_ahead_slice(6).to_uppercase() == "SYSTEM" {
                                 self.stream.seek(SeekCur, 6);
-                                self.state = State::AfterDocTypeSystemKeyword;
+                                self.state = State::AfterDOCTYPESystemKeyword;
                                 continue;
                             }
                             // Make sure the parser is on the correct position again since we just
@@ -1552,29 +1552,29 @@ impl<'stream> Tokenizer<'stream> {
                             self.stream.seek(SeekCur, -1);
                             self.set_quirks_mode(true);
                             self.stream.unread();
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::AfterDocTypePublicKeyword => {
+                State::AfterDOCTYPEPublicKeyword => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
-                            self.state = State::BeforeDocTypePublicIdentifier
+                            self.state = State::BeforeDOCTYPEPublicIdentifier
                         }
                         Ch('"') => {
                             self.parse_error(
                                 ParserError::MissingWhitespaceAfterDoctypePublicKeyword,
                             );
                             self.set_public_identifier(String::new());
-                            self.state = State::DocTypePublicIdentifierDoubleQuoted;
+                            self.state = State::DOCTYPEPublicIdentifierDoubleQuoted;
                         }
                         Ch('\'') => {
                             self.parse_error(
                                 ParserError::MissingWhitespaceAfterDoctypePublicKeyword,
                             );
                             self.set_public_identifier(String::new());
-                            self.state = State::DocTypePublicIdentifierSingleQuoted;
+                            self.state = State::DOCTYPEPublicIdentifierSingleQuoted;
                         }
                         Ch('>') => {
                             self.parse_error(ParserError::MissingDoctypePublicIdentifier);
@@ -1594,11 +1594,11 @@ impl<'stream> Tokenizer<'stream> {
                             );
                             self.stream.unread();
                             self.set_quirks_mode(true);
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::BeforeDocTypePublicIdentifier => {
+                State::BeforeDOCTYPEPublicIdentifier => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
@@ -1606,11 +1606,11 @@ impl<'stream> Tokenizer<'stream> {
                         }
                         Ch('"') => {
                             self.set_public_identifier(String::new());
-                            self.state = State::DocTypePublicIdentifierDoubleQuoted;
+                            self.state = State::DOCTYPEPublicIdentifierDoubleQuoted;
                         }
                         Ch('\'') => {
                             self.set_public_identifier(String::new());
-                            self.state = State::DocTypePublicIdentifierSingleQuoted;
+                            self.state = State::DOCTYPEPublicIdentifierSingleQuoted;
                         }
                         Ch('>') => {
                             self.parse_error(ParserError::MissingDoctypePublicIdentifier);
@@ -1630,14 +1630,14 @@ impl<'stream> Tokenizer<'stream> {
                                 ParserError::MissingQuoteBeforeDoctypePublicIdentifier,
                             );
                             self.set_quirks_mode(true);
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::DocTypePublicIdentifierDoubleQuoted => {
+                State::DOCTYPEPublicIdentifierDoubleQuoted => {
                     let c = self.read_char();
                     match c {
-                        Ch('"') => self.state = State::AfterDoctypePublicIdentifier,
+                        Ch('"') => self.state = State::AfterDOCTYPEPublicIdentifier,
                         Ch(CHAR_NUL) => {
                             self.parse_error(ParserError::UnexpectedNullCharacter);
                             self.add_public_identifier(CHAR_REPLACEMENT);
@@ -1657,10 +1657,10 @@ impl<'stream> Tokenizer<'stream> {
                         _ => self.add_public_identifier(c.into()),
                     }
                 }
-                State::DocTypePublicIdentifierSingleQuoted => {
+                State::DOCTYPEPublicIdentifierSingleQuoted => {
                     let c = self.read_char();
                     match c {
-                        Ch('\'') => self.state = State::AfterDoctypePublicIdentifier,
+                        Ch('\'') => self.state = State::AfterDOCTYPEPublicIdentifier,
                         Ch(CHAR_NUL) => {
                             self.parse_error(ParserError::UnexpectedNullCharacter);
                             self.add_public_identifier(CHAR_REPLACEMENT);
@@ -1680,11 +1680,11 @@ impl<'stream> Tokenizer<'stream> {
                         _ => self.add_public_identifier(c.into()),
                     }
                 }
-                State::AfterDoctypePublicIdentifier => {
+                State::AfterDOCTYPEPublicIdentifier => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
-                            self.state = State::BetweenDocTypePublicAndSystemIdentifiers
+                            self.state = State::BetweenDOCTYPEPublicAndSystemIdentifiers
                         }
                         Ch('>') => {
                             self.emit_current_token();
@@ -1693,12 +1693,12 @@ impl<'stream> Tokenizer<'stream> {
                         Ch('"') => {
                             self.parse_error(ParserError::MissingWhitespaceBetweenDoctypePublicAndSystemIdentifiers);
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierDoubleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierDoubleQuoted;
                         }
                         Ch('\'') => {
                             self.parse_error(ParserError::MissingWhitespaceBetweenDoctypePublicAndSystemIdentifiers);
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierSingleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierSingleQuoted;
                         }
                         Eof => {
                             self.parse_error(ParserError::EofInDoctype);
@@ -1712,11 +1712,11 @@ impl<'stream> Tokenizer<'stream> {
                             );
                             self.stream.unread();
                             self.set_quirks_mode(true);
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::BetweenDocTypePublicAndSystemIdentifiers => {
+                State::BetweenDOCTYPEPublicAndSystemIdentifiers => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
@@ -1728,11 +1728,11 @@ impl<'stream> Tokenizer<'stream> {
                         }
                         Ch('"') => {
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierDoubleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierDoubleQuoted;
                         }
                         Ch('\'') => {
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierSingleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierSingleQuoted;
                         }
                         Eof => {
                             self.parse_error(ParserError::EofInDoctype);
@@ -1746,29 +1746,29 @@ impl<'stream> Tokenizer<'stream> {
                             );
                             self.stream.unread();
                             self.set_quirks_mode(true);
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::AfterDocTypeSystemKeyword => {
+                State::AfterDOCTYPESystemKeyword => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
-                            self.state = State::BeforeDocTypeSystemIdentifier
+                            self.state = State::BeforeDOCTYPESystemIdentifier
                         }
                         Ch('"') => {
                             self.parse_error(
                                 ParserError::MissingWhitespaceAfterDoctypeSystemKeyword,
                             );
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierDoubleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierDoubleQuoted;
                         }
                         Ch('\'') => {
                             self.parse_error(
                                 ParserError::MissingWhitespaceAfterDoctypeSystemKeyword,
                             );
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierSingleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierSingleQuoted;
                         }
                         Ch('>') => {
                             self.parse_error(ParserError::MissingDoctypeSystemIdentifier);
@@ -1788,11 +1788,11 @@ impl<'stream> Tokenizer<'stream> {
                             );
                             self.stream.unread();
                             self.set_quirks_mode(true);
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::BeforeDocTypeSystemIdentifier => {
+                State::BeforeDOCTYPESystemIdentifier => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
@@ -1800,11 +1800,11 @@ impl<'stream> Tokenizer<'stream> {
                         }
                         Ch('"') => {
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierDoubleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierDoubleQuoted;
                         }
                         Ch('\'') => {
                             self.set_system_identifier(String::new());
-                            self.state = State::DocTypeSystemIdentifierSingleQuoted;
+                            self.state = State::DOCTYPESystemIdentifierSingleQuoted;
                         }
                         Ch('>') => {
                             self.parse_error(ParserError::MissingDoctypeSystemIdentifier);
@@ -1824,14 +1824,14 @@ impl<'stream> Tokenizer<'stream> {
                             );
                             self.stream.unread();
                             self.set_quirks_mode(true);
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::DocTypeSystemIdentifierDoubleQuoted => {
+                State::DOCTYPESystemIdentifierDoubleQuoted => {
                     let c = self.read_char();
                     match c {
-                        Ch('"') => self.state = State::AfterDocTypeSystemIdentifier,
+                        Ch('"') => self.state = State::AfterDOCTYPESystemIdentifier,
                         Ch(CHAR_NUL) => {
                             self.parse_error(ParserError::UnexpectedNullCharacter);
                             self.add_system_identifier(CHAR_REPLACEMENT);
@@ -1851,10 +1851,10 @@ impl<'stream> Tokenizer<'stream> {
                         _ => self.add_system_identifier(c.into()),
                     }
                 }
-                State::DocTypeSystemIdentifierSingleQuoted => {
+                State::DOCTYPESystemIdentifierSingleQuoted => {
                     let c = self.read_char();
                     match c {
-                        Ch('\'') => self.state = State::AfterDocTypeSystemIdentifier,
+                        Ch('\'') => self.state = State::AfterDOCTYPESystemIdentifier,
                         Ch(CHAR_NUL) => {
                             self.parse_error(ParserError::UnexpectedNullCharacter);
                             self.add_system_identifier(CHAR_REPLACEMENT);
@@ -1874,7 +1874,7 @@ impl<'stream> Tokenizer<'stream> {
                         _ => self.add_system_identifier(c.into()),
                     }
                 }
-                State::AfterDocTypeSystemIdentifier => {
+                State::AfterDOCTYPESystemIdentifier => {
                     let c = self.read_char();
                     match c {
                         Ch(CHAR_TAB | CHAR_LF | CHAR_FF | CHAR_SPACE) => {
@@ -1895,11 +1895,11 @@ impl<'stream> Tokenizer<'stream> {
                                 ParserError::UnexpectedCharacterAfterDoctypeSystemIdentifier,
                             );
                             self.stream.unread();
-                            self.state = State::BogusDocType;
+                            self.state = State::BogusDOCTYPE;
                         }
                     }
                 }
-                State::BogusDocType => {
+                State::BogusDOCTYPE => {
                     let c = self.read_char();
                     match c {
                         Ch('>') => {
@@ -2034,7 +2034,7 @@ impl<'stream> Tokenizer<'stream> {
                 name.push(c);
             }
             Some(Token::DocType { name, .. }) => {
-                // Doctype can have an optional name
+                // DOCTYPE can have an optional name
                 match name {
                     Some(ref mut string) => string.push(c),
                     None => *name = Some(c.to_string()),

--- a/src/html5/tokenizer/state.rs
+++ b/src/html5/tokenizer/state.rs
@@ -1,78 +1,214 @@
 /// These are the states in which the tokenizer can be in.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum State {
+    /// 8.2.4.36 After attribute name state
     AfterAttributeName,
+
+    /// 8.2.4.42 After attribute value (quoted) state
     AfterAttributeValueQuoted,
-    AfterDocTypeName,
-    AfterDoctypePublicIdentifier,
-    AfterDocTypePublicKeyword,
-    AfterDocTypeSystemIdentifier,
-    AfterDocTypeSystemKeyword,
+
+    /// 8.2.4.55 After DOCTYPE name state
+    AfterDOCTYPEName,
+
+    /// 8.2.4.60 After DOCTYPE public identifier state
+    AfterDOCTYPEPublicIdentifier,
+
+    /// 8.2.4.56 After DOCTYPE public keyword state
+    AfterDOCTYPEPublicKeyword,
+
+    /// 8.2.4.66 After DOCTYPE system identifier state
+    AfterDOCTYPESystemIdentifier,
+
+    /// 8.2.4.62 After DOCTYPE system keyword state
+    AfterDOCTYPESystemKeyword,
+
+    /// 8.2.4.35 Attribute name state
     AttributeName,
+
+    /// 8.2.4.38 Attribute value (double-quoted) state
     AttributeValueDoubleQuoted,
+
+    /// 8.2.4.39 Attribute value (single-quoted) state
     AttributeValueSingleQuoted,
+
+    /// 8.2.4.40 Attribute value (unquoted) state
     AttributeValueUnquoted,
+
+    /// 8.2.4.34 Before attribute name state
     BeforeAttributeName,
+
+    /// 8.2.4.37 Before attribute value state
     BeforeAttributeValue,
-    BeforeDocTypeName,
-    BeforeDocTypePublicIdentifier,
-    BeforeDocTypeSystemIdentifier,
-    BetweenDocTypePublicAndSystemIdentifiers,
+
+    /// 8.2.4.53 Before DOCTYPE name state
+    BeforeDOCTYPEName,
+
+    /// 8.2.4.57 Before DOCTYPE public identifier state
+    BeforeDOCTYPEPublicIdentifier,
+
+    /// 8.2.4.63 Before DOCTYPE system identifier state
+    BeforeDOCTYPESystemIdentifier,
+
+    /// 8.2.4.61 Between DOCTYPE public and system identifiers state
+    BetweenDOCTYPEPublicAndSystemIdentifiers,
+
+    /// 8.2.4.44 Bogus comment state
     BogusComment,
-    BogusDocType,
+
+    /// 8.2.4.67 Bogus DOCTYPE state
+    BogusDOCTYPE,
+
+    /// 8.2.4.68 CDATA section state
     CDATASection,
+
     CDATASectionBracket,
     CDATASectionEnd,
+
+    /// 8.2.4.41 Character reference in attribute value state
     CharacterReferenceInAttributeValue,
+
+    /// 8.2.4.2 Character reference in data state
     CharacterReferenceInData,
+
+    /// 8.2.4.4 Character reference in RCDATA state
     CharacterReferenceInRcData,
+
+    /// 8.2.4.48 Comment state
     Comment,
+
+    /// 8.2.4.50 Comment end state
     CommentEnd,
+
+    /// 8.2.4.51 Comment end bang state
     CommentEndBang,
+
+    /// 8.2.4.49 Comment end dash state
     CommentEndDash,
+
     CommentLessThanSign,
     CommentLessThanSignBang,
     CommentLessThanSignBangDash,
     CommentLessThanSignBangDashDash,
+
+    /// 8.2.4.46 Comment start state
     CommentStart,
+
+    /// 8.2.4.47 Comment start dash state
     CommentStartDash,
+
+    /// 8.2.4.1 Data state
     Data,
-    DocType,
-    DocTypeName,
-    DocTypePublicIdentifierDoubleQuoted,
-    DocTypePublicIdentifierSingleQuoted,
-    DocTypeSystemIdentifierDoubleQuoted,
-    DocTypeSystemIdentifierSingleQuoted,
+
+    /// 8.2.4.52 DOCTYPE state
+    DOCTYPE,
+
+    /// 8.2.4.54 DOCTYPE name state
+    DOCTYPEName,
+
+    /// 8.2.4.58 DOCTYPE public identifier (double-quoted) state
+    DOCTYPEPublicIdentifierDoubleQuoted,
+
+    /// 8.2.4.59 DOCTYPE public identifier (single-quoted) state
+    DOCTYPEPublicIdentifierSingleQuoted,
+
+    /// 8.2.4.64 DOCTYPE system identifier (double-quoted) state
+    DOCTYPESystemIdentifierDoubleQuoted,
+
+    /// 8.2.4.65 DOCTYPE system identifier (single-quoted) state
+    DOCTYPESystemIdentifierSingleQuoted,
+
     EndTagOpen,
+
+    /// 8.2.4.45 Markup declaration open state
     MarkupDeclarationOpen,
+
+    /// 8.2.4.7 PLAINTEXT state
     PLAINTEXT,
+
+    /// 8.2.4.5 RAWTEXT state
     RAWTEXT,
-    RawTextEndTagName,
-    RawTextEndTagOpen,
-    RawTextLessThanSign,
+
+    /// 8.2.4.16 RAWTEXT end tag name state
+    RAWTEXTEndTagName,
+
+    /// 8.2.4.15 RAWTEXT end tag open state
+    RAWTEXTEndTagOpen,
+
+    /// 8.2.4.14 RAWTEXT less-than sign state
+    RAWTEXTLessThanSign,
+
+    /// 8.2.4.3 RCDATA state
     RCDATA,
+
+    /// 8.2.4.13 RCDATA end tag name state
     RCDATAEndTagName,
+
+    /// 8.2.4.12 RCDATA end tag open state
     RCDATAEndTagOpen,
+
+    /// 8.2.4.11 RCDATA less-than sign state
     RCDATALessThanSign,
+
+    /// 8.2.4.6 Script data state
     ScriptData,
+
+    /// 8.2.4.29 Script data double escaped state
     ScriptDataDoubleEscaped,
+
+    /// 8.2.4.30 Script data double escaped dash state
     ScriptDataDoubleEscapedDash,
+
+    /// 8.2.4.31 Script data double escaped dash dash state
     ScriptDataDoubleEscapedDashDash,
+
+    /// 8.2.4.32 Script data double escaped less-than sign state
     ScriptDataDoubleEscapedLessThanSign,
+
+    /// 8.2.4.33 Script data double escape end state
     ScriptDataDoubleEscapeEnd,
+
+    /// 8.2.4.28 Script data double escape start state
     ScriptDataDoubleEscapeStart,
+
+    /// 8.2.4.19 Script data end tag name state
     ScriptDataEndTagName,
+
+    /// 8.2.4.18 Script data end tag open state
     ScriptDataEndTagOpen,
+
+    /// 8.2.4.22 Script data escaped state
     ScriptDataEscaped,
+
+    /// 8.2.4.23 Script data escaped dash state
     ScriptDataEscapedDash,
+
+    /// 8.2.4.24 Script data escaped dash dash state
     ScriptDataEscapedDashDash,
+
+    /// 8.2.4.27 Script data escaped end tag name state
     ScriptDataEscapedEndTagName,
+
+    /// 8.2.4.26 Script data escaped end tag open state
     ScriptDataEscapedEndTagOpen,
+
+    /// 8.2.4.25 Script data escaped less-than sign state
     ScriptDataEscapedLessThanSign,
+
+    /// 8.2.4.20 Script data escape start state
     ScriptDataEscapeStart,
+
+    /// 8.2.4.21 Script data escape start dash state
     ScriptDataEscapeStartDash,
+
+    /// 8.2.4.17 Script data less-than sign state
     ScriptDataLessThenSign,
+
+    /// 8.2.4.43 Self-closing start tag state
     SelfClosingStart,
+
+    /// 8.2.4.10 Tag name state
     TagName,
+
+    /// 8.2.4.8 Tag open state
     TagOpen,
 }


### PR DESCRIPTION
This PR
* Adds comments to the `State` enum variants pointing to sections of the [HTML5 tokenization spec](https://www.w3.org/TR/2011/WD-html5-20110113/tokenization.html) when a section is available
* Brings some of the state names closer in line with what is seen in the spec
