### PR TITLE
Implemented doctype nodes

### DIFF
--- a/src/bin/parser-test.rs
+++ b/src/bin/parser-test.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
         tests_failed: Vec::new(),
     };
 
-    let filenames = Some(&["tests19.dat"][..]);
+    let filenames = Some(&["doctype01.dat"][..]);
     let fixtures = testing::tree_construction::fixtures(filenames).expect("fixtures");
 
     for fixture_file in fixtures {
@@ -207,8 +207,10 @@ fn print_node_result(result: &SubtreeResult) {
             println!("❌ {expected}, Found unexpected attribute: {name}");
         }
 
-        Some(NodeResult::ElementMatchFailure { name, expected, .. }) => {
-            println!("❌ {expected}, Found unexpected element node: {name}");
+        Some(NodeResult::ElementMatchFailure {
+            actual, expected, ..
+        }) => {
+            println!("❌ {expected}, Found unexpected element node: {actual}");
         }
 
         Some(NodeResult::TextMatchSuccess { expected }) => {
@@ -217,6 +219,12 @@ fn print_node_result(result: &SubtreeResult) {
 
         Some(NodeResult::TextMatchFailure { expected, text, .. }) => {
             println!("❌ {expected}, Found unexpected text node: {text}");
+        }
+
+        Some(NodeResult::DocTypeMatchFailure {
+            actual, expected, ..
+        }) => {
+            println!("❌ {actual}, Found unexpected doctype node: {expected}");
         }
 
         Some(NodeResult::CommentMatchFailure {

--- a/src/html5/node.rs
+++ b/src/html5/node.rs
@@ -1,5 +1,6 @@
 use super::parser::document::{Document, DocumentHandle};
 use crate::html5::node::data::comment::CommentData;
+use crate::html5::node::data::doctype::DocTypeData;
 use crate::html5::node::data::document::DocumentData;
 use crate::html5::node::data::element::ElementData;
 use crate::html5::node::data::text::TextData;
@@ -21,6 +22,7 @@ pub mod data;
 #[derive(Debug, PartialEq)]
 pub enum NodeType {
     Document,
+    DocType,
     Text,
     Comment,
     Element,
@@ -31,6 +33,8 @@ pub enum NodeType {
 pub enum NodeData {
     /// Represents a document
     Document(DocumentData),
+    // Represents a doctype
+    DocType(DocTypeData),
     /// Represents a text
     Text(TextData),
     /// Represents a comment
@@ -244,6 +248,24 @@ impl Node {
         }
     }
 
+    pub fn new_doctype(
+        document: &DocumentHandle,
+        name: &str,
+        pub_identifier: &str,
+        sys_identifier: &str,
+    ) -> Self {
+        Node {
+            id: Default::default(),
+            parent: None,
+            children: vec![],
+            data: NodeData::DocType(DocTypeData::new(name, pub_identifier, sys_identifier)),
+            name: "".to_string(),
+            namespace: None,
+            document: Document::clone(document),
+            is_registered: false,
+        }
+    }
+
     /// Create a new element node with the given name and attributes and namespace
     pub fn new_element(
         document: &DocumentHandle,
@@ -340,6 +362,7 @@ impl NodeTrait for Node {
     fn type_of(&self) -> NodeType {
         match self.data {
             NodeData::Document { .. } => NodeType::Document,
+            NodeData::DocType { .. } => NodeType::DocType,
             NodeData::Text { .. } => NodeType::Text,
             NodeData::Comment { .. } => NodeType::Comment,
             NodeData::Element { .. } => NodeType::Element,

--- a/src/html5/node/data.rs
+++ b/src/html5/node/data.rs
@@ -1,4 +1,5 @@
 pub mod comment;
+pub mod doctype;
 pub mod document;
 pub mod element;
 pub mod text;

--- a/src/html5/node/data/doctype.rs
+++ b/src/html5/node/data/doctype.rs
@@ -1,0 +1,33 @@
+use core::fmt::{Debug, Formatter};
+use std::fmt;
+
+#[derive(PartialEq, Clone)]
+/// Data structure for document nodes
+pub struct DocTypeData {
+    pub name: String,
+    pub pub_identifier: String,
+    pub sys_identifier: String,
+}
+
+impl Default for DocTypeData {
+    fn default() -> Self {
+        Self::new("", "", "")
+    }
+}
+
+impl Debug for DocTypeData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("DocTypeData");
+        debug.finish()
+    }
+}
+
+impl DocTypeData {
+    pub(crate) fn new(name: &str, pub_identifier: &str, sys_identifier: &str) -> Self {
+        DocTypeData {
+            name: name.to_string(),
+            pub_identifier: pub_identifier.to_string(),
+            sys_identifier: sys_identifier.to_string(),
+        }
+    }
+}

--- a/src/html5/parser.rs
+++ b/src/html5/parser.rs
@@ -1751,11 +1751,17 @@ impl<'stream> Html5Parser<'stream> {
     /// Create a new node that is not connected or attached to the document arena
     fn create_node(&self, token: &Token, namespace: &str) -> Node {
         match token {
-            Token::DocType { name, .. } => {
-                let val = format!("!DOCTYPE {}", name.as_deref().unwrap_or(""),);
-
-                return Node::new_element(&self.document, val.as_str(), HashMap::new(), namespace);
-            }
+            Token::DocType {
+                name,
+                pub_identifier,
+                sys_identifier,
+                ..
+            } => Node::new_doctype(
+                &self.document,
+                &name.clone().unwrap_or_default(),
+                &pub_identifier.clone().unwrap_or_default(),
+                &sys_identifier.clone().unwrap_or_default(),
+            ),
             Token::StartTag {
                 name, attributes, ..
             } => Node::new_element(&self.document, name, attributes.clone(), namespace),

--- a/src/html5/parser/document.rs
+++ b/src/html5/parser/document.rs
@@ -1,4 +1,5 @@
 use crate::html5::node::arena::NodeArena;
+use crate::html5::node::data::doctype::DocTypeData;
 use crate::html5::node::data::{comment::CommentData, text::TextData};
 use crate::html5::node::HTML_NAMESPACE;
 use crate::html5::node::{Node, NodeData, NodeId};
@@ -493,6 +494,16 @@ impl Document {
         match &node.data {
             NodeData::Document(_) => {
                 _ = writeln!(f, "{}Document", buffer);
+            }
+            NodeData::DocType(DocTypeData {
+                name,
+                pub_identifier,
+                sys_identifier,
+            }) => {
+                _ = writeln!(
+                    f,
+                    r#"{buffer}<!DOCTYPE {name} "{pub_identifier}" "{sys_identifier}">"#,
+                );
             }
             NodeData::Text(TextData { value, .. }) => {
                 _ = writeln!(f, "{}\"{}\"", buffer, value);

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -2,6 +2,7 @@ mod parser;
 
 use self::parser::{ErrorSpec, ScriptMode, TestSpec, QUOTED_DOUBLE_NEWLINE};
 use super::FIXTURE_ROOT;
+use crate::html5::node::data::doctype::DocTypeData;
 use crate::html5::node::{HTML_NAMESPACE, MATHML_NAMESPACE, SVG_NAMESPACE};
 use crate::html5::parser::document::DocumentBuilder;
 use crate::html5::parser::tree_builder::TreeBuilder;
@@ -70,13 +71,21 @@ pub enum NodeResult {
     },
 
     /// The element matches the expected element
-    ElementMatchSuccess { actual: String },
+    ElementMatchSuccess {
+        actual: String,
+    },
 
     /// A text node did not match
     TextMatchFailure {
         actual: String,
         expected: String,
         text: String,
+    },
+
+    // A doctype node did not match
+    DocTypeMatchFailure {
+        actual: String,
+        expected: String,
     },
 
     /// A comment node did not match
@@ -87,7 +96,9 @@ pub enum NodeResult {
     },
 
     /// A text node matches
-    TextMatchSuccess { expected: String },
+    TextMatchSuccess {
+        expected: String,
+    },
 }
 
 pub struct SubtreeResult {
@@ -170,6 +181,12 @@ impl Test {
                     actual, expected, ..
                 }) => {
                     panic!("text match failed, wanted: [{expected}], got: [{actual}]");
+                }
+
+                Some(NodeResult::DocTypeMatchFailure {
+                    actual, expected, ..
+                }) => {
+                    panic!("doctype match failed, wanted: [{expected}], got: [{actual}]");
                 }
 
                 Some(NodeResult::ElementMatchFailure {
@@ -283,6 +300,43 @@ impl Test {
         let node = document.get_node_by_id(node_idx).unwrap();
 
         let node_result = match &node.data {
+            NodeData::DocType(DocTypeData {
+                name,
+                pub_identifier,
+                sys_identifier,
+            }) => {
+                let doctype_text = if pub_identifier.is_empty() && sys_identifier.is_empty() {
+                    // <!DOCTYPE html>
+                    name.to_string()
+                } else {
+                    // <!DOCTYPE html "pubid" "sysid">
+                    format!(r#"{name} "{pub_identifier}" "{sys_identifier}""#,)
+                };
+
+                let actual = format!(
+                    "|{}<!DOCTYPE {}>",
+                    " ".repeat(indent as usize * 2 + 1),
+                    doctype_text.trim(),
+                );
+
+                let expected = self.document[next_expected_idx as usize].to_owned();
+                next_expected_idx += 1;
+
+                if actual != expected {
+                    let node = Some(NodeResult::DocTypeMatchFailure {
+                        actual,
+                        expected: "".to_string(),
+                    });
+
+                    return SubtreeResult {
+                        node,
+                        children: vec![],
+                        next_expected_idx: None,
+                    };
+                }
+
+                Some(NodeResult::TextMatchSuccess { expected })
+            }
             NodeData::Element(element) => {
                 let prefix: String = match &node.namespace {
                     Some(namespace) => match namespace.as_str() {
@@ -357,7 +411,6 @@ impl Test {
 
                 Some(NodeResult::ElementMatchSuccess { actual })
             }
-
             NodeData::Text(text) => {
                 let actual = format!(
                     "|{}\"{}\"",
@@ -398,7 +451,6 @@ impl Test {
 
                 Some(NodeResult::TextMatchSuccess { expected })
             }
-
             NodeData::Comment(comment) => {
                 let actual = format!(
                     "|{}<!-- {} -->",


### PR DESCRIPTION
This PR implements a new node type named "doctype". It is used for the `<!doctype>`  tags which works a bit differently than regular tags.

The common tree structure would be:

```
|- <document node (0)>
   |- <doctype node (1)>
   |- <element node "html" (2)>
   |  |- <element node "head" (3)>
   |  |   |- <element node "title" (4)>
   |- <element node "body" (5)>
```

Note that the document node (0) is the root node. We use a separate document node type for this, but this isn't really used anywhere except for holding a html tree.

The "document" which we use and create with `DocumentBuilder::new_document()` is a the structure that holds the node arena and other things. This may be a bit confusing in naming, especially when we will get to the "DOM" document (which is an interface that interacts with our document-tree).

Anyway, for now.. the doctype works, and we are at 92% pass rate.