### PR TITLE
Continue revisiting tokenization

### DIFF
--- a/src/bin/gosub-parser.rs
+++ b/src/bin/gosub-parser.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use gosub_engine::html5::parser::document::{Document, DocumentBuilder};
-use gosub_engine::html5::{
-    input_stream::{Confidence, Encoding, InputStream},
-    parser::Html5Parser,
+use gosub_engine::{
+    bytes::{CharIterator, Confidence, Encoding},
+    html5::parser::Html5Parser,
 };
 use std::fs;
 use std::process::exit;
@@ -32,17 +32,17 @@ fn main() -> Result<()> {
         fs::read_to_string(&url)?
     };
 
-    let mut stream = InputStream::new();
-    stream.read_from_str(&html, Some(Encoding::UTF8));
-    stream.set_confidence(Confidence::Certain);
+    let mut chars = CharIterator::new();
+    chars.read_from_str(&html, Some(Encoding::UTF8));
+    chars.set_confidence(Confidence::Certain);
 
     // If the encoding confidence is not Confidence::Certain, we should detect the encoding.
-    if !stream.is_certain_encoding() {
-        stream.detect_encoding()
+    if !chars.is_certain_encoding() {
+        chars.detect_encoding()
     }
 
     let document = DocumentBuilder::new_document();
-    let parse_errors = Html5Parser::parse_document(&mut stream, Document::clone(&document), None)?;
+    let parse_errors = Html5Parser::parse_document(&mut chars, Document::clone(&document), None)?;
 
     println!("Generated tree: \n\n {}", document);
 

--- a/src/bin/test-user-agent.rs
+++ b/src/bin/test-user-agent.rs
@@ -1,7 +1,7 @@
 use gosub_engine::html5::parser::document::DocumentBuilder;
 use gosub_engine::{
+    bytes::{CharIterator, Confidence, Encoding},
     html5::{
-        input_stream::{Confidence, Encoding, InputStream},
         node::{Node, NodeData},
         parser::{document::Document, Html5Parser},
     },
@@ -26,17 +26,17 @@ fn main() -> Result<()> {
     }
     let html = response.into_string()?;
 
-    let mut stream = InputStream::new();
-    stream.read_from_str(&html, Some(Encoding::UTF8));
-    stream.set_confidence(Confidence::Certain);
+    let mut chars = CharIterator::new();
+    chars.read_from_str(&html, Some(Encoding::UTF8));
+    chars.set_confidence(Confidence::Certain);
 
     // If the encoding confidence is not Confidence::Certain, we should detect the encoding.
-    if !stream.is_certain_encoding() {
-        stream.detect_encoding()
+    if !chars.is_certain_encoding() {
+        chars.detect_encoding()
     }
 
     let document = DocumentBuilder::new_document();
-    let parse_errors = Html5Parser::parse_document(&mut stream, Document::clone(&document), None)?;
+    let parse_errors = Html5Parser::parse_document(&mut chars, Document::clone(&document), None)?;
 
     match get_node_by_path(&document.get(), vec!["html", "body"]) {
         None => {

--- a/src/css3/new_parser.rs
+++ b/src/css3/new_parser.rs
@@ -1,5 +1,5 @@
 use super::new_tokenizer::{Token, TokenKind};
-use crate::{css3::new_tokenizer::Tokenizer, html5::input_stream::InputStream};
+use crate::{bytes::CharIterator, css3::new_tokenizer::Tokenizer};
 
 struct Function {
     name: String,
@@ -26,7 +26,7 @@ impl<'stream> CSS3Parser<'stream> {
         CSS3Parser { tokenizer }
     }
 
-    pub fn from_input_stream(is: &mut InputStream) -> CSS3Parser {
+    pub fn from_input_stream(is: &mut CharIterator) -> CSS3Parser {
         CSS3Parser::new(Tokenizer::new(is))
     }
 

--- a/src/html5.rs
+++ b/src/html5.rs
@@ -5,7 +5,6 @@
 pub mod dom;
 pub mod element_class;
 pub mod error_logger;
-pub mod input_stream;
 pub mod node;
 pub mod parser;
 pub mod tokenizer;

--- a/src/html5/error_logger.rs
+++ b/src/html5/error_logger.rs
@@ -1,4 +1,4 @@
-use crate::html5::input_stream::Position;
+use crate::bytes::Position;
 use crate::types::ParseError;
 
 /// Possible parser error enumerated

--- a/src/html5/parser/helper.rs
+++ b/src/html5/parser/helper.rs
@@ -28,7 +28,7 @@ pub enum BookMark<NodeId> {
     InsertAfter(NodeId),
 }
 
-impl<'stream> Html5Parser<'stream> {
+impl Html5Parser<'_> {
     fn find_position_in_active_format(&self, node_id: &NodeId) -> Option<usize> {
         self.active_formatting_elements
             .iter()

--- a/src/html5/parser/lib.rs
+++ b/src/html5/parser/lib.rs
@@ -1,1 +1,0 @@
-pub mod nodes;

--- a/src/html5/parser/quirks.rs
+++ b/src/html5/parser/quirks.rs
@@ -7,7 +7,7 @@ pub enum QuirksMode {
     NoQuirks,
 }
 
-impl<'stream> Html5Parser<'stream> {
+impl Html5Parser<'_> {
     // returns the correct quirk mode for the given doctype
     pub(crate) fn identify_quirks_mode(
         &self,
@@ -155,14 +155,14 @@ static LIMITED_QUIRKS_PUB_IDENTIFIER_PREFIX_NOT_MISSING_SYS: &[&str] = &[
 
 #[cfg(test)]
 mod tests {
-    use crate::html5::input_stream::InputStream;
+    use crate::bytes::CharIterator;
     use crate::html5::parser::Html5Parser;
     use crate::html5::parser::QuirksMode;
 
     #[test]
     fn test_quirks_mode() {
-        let stream = &mut InputStream::new();
-        let parser = Html5Parser::new_parser(stream);
+        let chars = &mut CharIterator::new();
+        let parser = Html5Parser::new_parser(chars);
 
         assert_eq!(
             parser.identify_quirks_mode(&None, None, None, false),
@@ -247,8 +247,8 @@ mod tests {
 
     #[test]
     fn test_quirks_mode_force() {
-        let stream = &mut InputStream::new();
-        let parser = Html5Parser::new_parser(stream);
+        let chars = &mut CharIterator::new();
+        let parser = Html5Parser::new_parser(chars);
 
         assert_eq!(
             parser.identify_quirks_mode(&Some("html".to_string()), None, None, true),
@@ -321,8 +321,8 @@ mod tests {
 
     #[test]
     fn test_quirks_mode_sys() {
-        let stream = &mut InputStream::new();
-        let parser = Html5Parser::new_parser(stream);
+        let chars = &mut CharIterator::new();
+        let parser = Html5Parser::new_parser(chars);
 
         assert_eq!(
             parser.identify_quirks_mode(
@@ -346,8 +346,8 @@ mod tests {
 
     #[test]
     fn test_quirks_mode_sys_missing() {
-        let stream = &mut InputStream::new();
-        let parser = Html5Parser::new_parser(stream);
+        let chars = &mut CharIterator::new();
+        let parser = Html5Parser::new_parser(chars);
 
         assert_eq!(
             parser.identify_quirks_mode(

--- a/src/html5/tokenizer/token.rs
+++ b/src/html5/tokenizer/token.rs
@@ -1,17 +1,6 @@
 use crate::html5::tokenizer::CHAR_NUL;
 use std::collections::HashMap;
 
-/// The different tokens types that can be emitted by the tokenizer
-#[derive(Debug, PartialEq)]
-pub enum TokenType {
-    DocTypeToken,
-    StartTagToken,
-    EndTagToken,
-    CommentToken,
-    TextToken,
-    EofToken,
-}
-
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct Attribute {
     pub name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 extern crate core;
 
 pub mod api;
+pub mod bytes;
 #[allow(dead_code)]
 pub mod css3;
 #[allow(dead_code)]

--- a/src/testing/tokenizer.rs
+++ b/src/testing/tokenizer.rs
@@ -1,7 +1,7 @@
 use super::FIXTURE_ROOT;
+use crate::bytes::CharIterator;
 use crate::html5::{
     error_logger::ErrorLogger,
-    input_stream::InputStream,
     tokenizer::{
         state::State as TokenState,
         token::Token,
@@ -23,7 +23,7 @@ use std::{
 };
 
 pub struct TokenizerBuilder {
-    input_stream: InputStream,
+    chars: CharIterator,
     state: TokenState,
     last_start_tag: Option<String>,
 }
@@ -32,7 +32,7 @@ impl TokenizerBuilder {
     pub fn build(&mut self) -> Tokenizer<'_> {
         let error_logger = Rc::new(RefCell::new(ErrorLogger::new()));
         Tokenizer::new(
-            &mut self.input_stream,
+            &mut self.chars,
             Some(Options {
                 initial_state: self.state,
                 last_start_tag: self.last_start_tag.to_owned().unwrap_or(String::from("")),
@@ -184,16 +184,16 @@ impl TestSpec {
         }
 
         for state in states.into_iter() {
-            let mut is = InputStream::new();
+            let mut chars = CharIterator::new();
             let input = if self.double_escaped {
                 from_utf16_lossy(&self.input)
             } else {
                 self.input.to_string()
             };
-            is.read_from_str(input.as_str(), None);
+            chars.read_from_str(input.as_str(), None);
 
             let builder = TokenizerBuilder {
-                input_stream: is,
+                chars,
                 last_start_tag: self.last_start_tag.clone(),
                 state,
             };

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -7,8 +7,8 @@ use crate::html5::parser::document::DocumentBuilder;
 use crate::html5::parser::tree_builder::TreeBuilder;
 use crate::html5::parser::Html5ParserOptions;
 use crate::{
+    bytes::CharIterator,
     html5::{
-        input_stream::InputStream,
         node::{NodeData, NodeId},
         parser::{
             document::{Document, DocumentHandle},
@@ -244,18 +244,18 @@ impl Test {
         // Create a new parser
         let options = Html5ParserOptions { scripting_enabled };
 
-        let mut is = InputStream::new();
-        is.read_from_str(self.data(), None);
+        let mut chars = CharIterator::new();
+        chars.read_from_str(self.data(), None);
 
         let parse_errors = if is_fragment {
             Html5Parser::parse_fragment(
-                &mut is,
+                &mut chars,
                 Document::clone(&document),
                 &context_node.expect(""),
                 Some(options),
             )?
         } else {
-            Html5Parser::parse_document(&mut is, Document::clone(&document), Some(options))?
+            Html5Parser::parse_document(&mut chars, Document::clone(&document), Some(options))?
         };
 
         Ok((document, parse_errors))


### PR DESCRIPTION
Soon we'll need to think clearly about the different stages of a tokenization pipeline.  This PR begins to differentiate the stages that will be needed by
* Renaming `InputStream` to `CharIterator`
* Using "chars" in place of the more generic "stream", which will soon be too generic
* Moving `src/html5/input_stream.rs` to `src/bytes.rs`, which will become its own module, since it's shared between HTML5 and CSS3 (and probably other formats)

While we're here, let's drop the unused `TokenType` enum.