### PR TITLE
Hotfix: get tests passing again

### DIFF
--- a/examples/html5-parser.rs
+++ b/examples/html5-parser.rs
@@ -1,17 +1,17 @@
 use gosub_engine::html5::parser::document::{Document, DocumentBuilder};
-use gosub_engine::html5::{
-    input_stream::{Encoding, InputStream},
-    parser::Html5Parser,
+use gosub_engine::{
+    bytes::{CharIterator, Encoding},
+    html5::parser::Html5Parser,
 };
 
 fn main() {
     // Creates an input stream
-    let mut stream = InputStream::new();
-    stream.read_from_str("<p>Hello<b>world</b></p>", Some(Encoding::UTF8));
+    let mut chars = CharIterator::new();
+    chars.read_from_str("<p>Hello<b>world</b></p>", Some(Encoding::UTF8));
 
     // Initialize a document and feed it together with the stream to the html5 parser
     let document = DocumentBuilder::new_document();
-    let _ = Html5Parser::parse_document(&mut stream, Document::clone(&document), None);
+    let _ = Html5Parser::parse_document(&mut chars, Document::clone(&document), None);
 
     // document now contains the html5 node tree
     println!("Generated tree: \n\n {}", document);


### PR DESCRIPTION
After merging my recent PR, the tests on `main` started breaking.  I realize now it will be necessary to rebase and run tests again before merging a PR.  I am not used to needing to do this, perhaps because there's a way to configure GitHub to do it automatically before merging (and block merging if the tests fail).  I'm not sure.
