### PR TITLE
(#205) fix issues with insert_attribute

### DIFF
--- a/src/html5.rs
+++ b/src/html5.rs
@@ -9,3 +9,4 @@ pub mod input_stream;
 pub mod node;
 pub mod parser;
 pub mod tokenizer;
+pub mod util;

--- a/src/html5/util.rs
+++ b/src/html5/util.rs
@@ -1,0 +1,15 @@
+/// according to HTML5 spec: 3.2.3.1
+/// https://www.w3.org/TR/2011/WD-html5-20110405/elements.html#the-id-attribute
+pub(crate) fn is_valid_id_attribute_value(value: &str) -> bool {
+    if value.contains(char::is_whitespace) {
+        return false;
+    }
+
+    if value.is_empty() {
+        return false;
+    }
+
+    // must contain at least one character,
+    // but doesn't specify it should *start* with a character
+    value.contains(char::is_alphabetic)
+}


### PR DESCRIPTION
Fixing some logical issues according to #205 

Thanks to @emwalker for cleaning up the `insert_id_attribute` implementation.

There's still some follow up work (adding support for `class` and inserting generic attributes) but those will be separate issues - all current tests are passing for now.