### PR TITLE
fixed

### DIFF
--- a/src/html5/parser.rs
+++ b/src/html5/parser.rs
@@ -513,13 +513,12 @@ impl<'chars> Html5Parser<'chars> {
             }
             Token::StartTag {
                 name, attributes, ..
-            } if name == "font" => {
-                if attributes.contains_key("color")
+            } if name == "font"
+                && (attributes.contains_key("color")
                     || attributes.contains_key("face")
-                    || attributes.contains_key("size")
-                {
-                    self.process_unexpected_html_tag();
-                }
+                    || attributes.contains_key("size")) =>
+            {
+                self.process_unexpected_html_tag();
             }
             Token::EndTag { name, .. } if name == "br" || name == "p" => {
                 self.process_unexpected_html_tag();

--- a/src/html5/parser.rs
+++ b/src/html5/parser.rs
@@ -3829,6 +3829,9 @@ impl<'chars> Html5Parser<'chars> {
 
     /// Find the correct tokenizer state when we are about to parse a fragment case
     fn find_initial_state_for_context(&self, context_node: &Node) -> State {
+        if !context_node.is_namespace(HTML_NAMESPACE) {
+            return State::Data;
+        }
         match context_node.name.as_str() {
             "title" | "textarea" => State::RCDATA,
             "style" | "xmp" | "iframe" | "noembed" | "noframes" => State::RAWTEXT,

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -614,12 +614,23 @@ pub fn fixtures(filenames: Option<&[&str]>) -> Result<Vec<FixtureFile>> {
     for entry in fs::read_dir(root)? {
         let path = entry?.path();
 
-        if !use_fixture(filenames, &path) {
-            continue;
-        }
+        if path.is_file() {
+            if !use_fixture(filenames, &path) {
+                continue;
+            }
 
-        let file = fixture_from_path(&path)?;
-        files.push(file);
+            let file = fixture_from_path(&path)?;
+            files.push(file);
+        } else {
+            for subentry in fs::read_dir(path)? {
+                let path = subentry?.path();
+                if !use_fixture(filenames, &path) {
+                    continue;
+                }
+                let file = fixture_from_path(&path)?;
+                files.push(file);
+            }
+        }
     }
 
     Ok(files)

--- a/src/testing/tree_construction.rs
+++ b/src/testing/tree_construction.rs
@@ -235,14 +235,23 @@ impl Test {
             // First, create a (fake) main document that contains only the fragment as node
             let main_document = DocumentBuilder::new_document();
             let mut main_document = Document::clone(&main_document);
+            let (element, namespace) = if fragment.starts_with("svg ") {
+                (
+                    fragment.strip_prefix("svg ").unwrap().to_string(),
+                    SVG_NAMESPACE,
+                )
+            } else if fragment.starts_with("math ") {
+                (
+                    fragment.strip_prefix("math ").unwrap().to_string(),
+                    MATHML_NAMESPACE,
+                )
+            } else {
+                (fragment, HTML_NAMESPACE)
+            };
 
             // Add context node
-            let context_node_id = main_document.create_element(
-                fragment.as_str(),
-                NodeId::root(),
-                None,
-                HTML_NAMESPACE,
-            );
+            let context_node_id =
+                main_document.create_element(element.as_str(), NodeId::root(), None, namespace);
             context_node = Some(
                 main_document
                     .get()

--- a/tests/tree_construction.rs
+++ b/tests/tree_construction.rs
@@ -49,7 +49,7 @@ lazy_static! {
 // #[test_case("domjs-unsafe.dat")]
 #[test_case("entities01.dat")]
 #[test_case("entities02.dat")]
-// #[test_case("foreign-fragment.dat")]
+#[test_case("foreign-fragment.dat")]
 #[test_case("html5test-com.dat")]
 #[test_case("inbody01.dat")]
 #[test_case("isindex.dat")]


### PR DESCRIPTION
fragment-case had done. 
Using an workaround way, currently except template content case and scripted case, all had done. So IMO, should deal with the parser and tokenizer cycle dependence problem.