### PR TITLE
Add document querying

### DIFF
--- a/src/html5/parser.rs
+++ b/src/html5/parser.rs
@@ -1,5 +1,6 @@
 mod attr_replacements;
 pub mod document;
+pub mod query;
 mod quirks;
 pub mod tree_builder;
 

--- a/src/html5/parser/query.rs
+++ b/src/html5/parser/query.rs
@@ -1,0 +1,130 @@
+#[derive(Debug, PartialEq)]
+pub enum Condition {
+    EqualsTag(String),
+    EqualsId(String),
+    ContainsClass(String),
+    ContainsAttribute(String),
+    ContainsChildTag(String),
+    HasParentTag(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SearchType {
+    Uninitialized,
+    FindFirst,
+    FindAll,
+}
+
+pub struct Query {
+    pub(crate) conditions: Vec<Condition>,
+    pub(crate) search_type: SearchType,
+}
+
+impl Query {
+    pub(crate) fn new() -> Self {
+        Self {
+            conditions: Vec::new(),
+            search_type: SearchType::Uninitialized,
+        }
+    }
+
+    pub(crate) fn equals_tag(mut self, tag_name: &str) -> Self {
+        self.conditions
+            .push(Condition::EqualsTag(tag_name.to_owned()));
+        self
+    }
+
+    pub(crate) fn equals_id(mut self, id: &str) -> Self {
+        self.conditions.push(Condition::EqualsId(id.to_owned()));
+        self
+    }
+
+    pub(crate) fn contains_class(mut self, class: &str) -> Self {
+        self.conditions
+            .push(Condition::ContainsClass(class.to_owned()));
+        self
+    }
+
+    pub(crate) fn contains_attribute(mut self, attribute: &str) -> Self {
+        self.conditions
+            .push(Condition::ContainsAttribute(attribute.to_owned()));
+        self
+    }
+
+    pub(crate) fn contains_child_tag(mut self, child_tag: &str) -> Self {
+        self.conditions
+            .push(Condition::ContainsChildTag(child_tag.to_owned()));
+        self
+    }
+
+    pub(crate) fn has_parent_tag(mut self, parent_tag: &str) -> Self {
+        self.conditions
+            .push(Condition::HasParentTag(parent_tag.to_owned()));
+        self
+    }
+
+    pub(crate) fn find_first(mut self) -> Self {
+        self.search_type = SearchType::FindFirst;
+        self
+    }
+
+    pub(crate) fn find_all(mut self) -> Self {
+        self.search_type = SearchType::FindAll;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::html5::parser::query::{Condition, Query, SearchType};
+
+    #[test]
+    fn uninitialized() {
+        let query = Query::new().equals_tag("div").equals_id("myid");
+        assert_eq!(query.search_type, SearchType::Uninitialized);
+    }
+
+    #[test]
+    fn find_first() {
+        let query = Query::new().find_first();
+        assert_eq!(query.search_type, SearchType::FindFirst);
+    }
+
+    #[test]
+    fn find_all() {
+        let query = Query::new().find_all();
+        assert_eq!(query.search_type, SearchType::FindAll);
+    }
+
+    #[test]
+    fn build_conditions() {
+        let query = Query::new()
+            .equals_tag("div")
+            .equals_id("myid")
+            .contains_class("myclass")
+            .contains_attribute("myattr")
+            .contains_child_tag("h1")
+            .has_parent_tag("html")
+            .find_first();
+
+        assert_eq!(query.conditions.len(), 6);
+        assert_eq!(query.conditions[0], Condition::EqualsTag("div".to_owned()));
+        assert_eq!(query.conditions[1], Condition::EqualsId("myid".to_owned()));
+        assert_eq!(
+            query.conditions[2],
+            Condition::ContainsClass("myclass".to_owned())
+        );
+        assert_eq!(
+            query.conditions[3],
+            Condition::ContainsAttribute("myattr".to_owned())
+        );
+        assert_eq!(
+            query.conditions[4],
+            Condition::ContainsChildTag("h1".to_owned())
+        );
+        assert_eq!(
+            query.conditions[5],
+            Condition::HasParentTag("html".to_owned())
+        );
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,9 @@ pub enum Error {
 
     #[error("document task error: {0}")]
     DocumentTask(String),
+
+    #[error("query error: {0}")]
+    Query(String),
 }
 
 /// Result that can be returned which holds either T or an Error


### PR DESCRIPTION
This implements a `Query` builder to pass to `DocumentHandle.query()` method to traverse the tree and return all node ID(s) that match the predicate. This also supports a `FindFirst` and `FindAll` search type. The searching of the tree terminates early on `FindFirst`.

I need to add some notes in the actual `query.rs` file explaining more of its usage, but given a `Query` instance, a node must match ALL conditions provided in the query (i.e., each condition is treated as an AND condition) in order to be returned.

I also want to add a simple extension `DocumentHandle.query_multiple` (or something along those lines) which would take a `Vec<Query>` list of predicates and check if a node matches at least one in order to be returned (to support OR-like conditionals.)