### PR TITLE
Add document tree iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ target/
 *.swo*
 *.swp*
 
-# Local testing 
+# Local testing
 local/
+
+# mac
+.DS_Store

--- a/src/html5/parser/tree_builder.rs
+++ b/src/html5/parser/tree_builder.rs
@@ -17,10 +17,10 @@ pub trait TreeBuilder {
     ) -> NodeId;
 
     /// Create a new text node with the given content and append it to a parent.
-    fn create_text(&mut self, content: &str, parent_id: NodeId);
+    fn create_text(&mut self, content: &str, parent_id: NodeId) -> NodeId;
 
     /// Create a new comment node with the given content and append it to a parent.
-    fn create_comment(&mut self, content: &str, parent_id: NodeId);
+    fn create_comment(&mut self, content: &str, parent_id: NodeId) -> NodeId;
 
     /// Insert/update an attribute for an element node.
     fn insert_attribute(&mut self, key: &str, value: &str, element_id: NodeId) -> Result<()>;


### PR DESCRIPTION
This adds a `TreeIterator` which takes a `&DocumentHandle` and constructs an iterator which walks through the tree one node at a time in tree order.

EDIT: below statement is incorrect, mutations are reflected in the iterator if it's still kept "open." I added a warning in the struct description about this.
~~This iterator is a snapshot of the document at the time the iterator is created and is not updated from mutations. In that case, a new iterator must be created.~~

At the moment, the iterator returns `NodeId`s (thanks for the help from @emwalker) which is good enough for now but ideally I would like this to return some type of `&Node` or `Rc<Node>` that the user agent can use directly without having to touch the document's "internals"

`DocumentHandle.query()` has been updated to use this new iterator as well which still passes all tests