### PR TITLE
make TreeIterator constructor public

### DIFF
--- a/src/html5/parser/document.rs
+++ b/src/html5/parser/document.rs
@@ -905,7 +905,7 @@ pub struct TreeIterator {
 }
 
 impl TreeIterator {
-    fn new(document: &DocumentHandle) -> Self {
+    pub fn new(document: &DocumentHandle) -> Self {
         Self {
             current_node_id: None,
             document: Document::clone(document),


### PR DESCRIPTION
User agent cannot create an iterator since it's private..