### PR TITLE
Remove some duplicate code in render tree

### DIFF
--- a/src/render_tree.rs
+++ b/src/render_tree.rs
@@ -110,7 +110,7 @@ impl RenderTree {
                             "h5" => Node::new_heading5,
                             "h6" => Node::new_heading6,
                             "p" => Node::new_paragraph,
-                            _ => todo!(), /* add more here, for now ignore */
+                            _ => continue, /* add more here, for now ignore */
                         }(&mut self.position);
 
                         let new_node = Rc::new(RefCell::new(new_node));

--- a/src/render_tree.rs
+++ b/src/render_tree.rs
@@ -164,168 +164,74 @@ impl Node {
         }
     }
 
+    fn new_text(node: TextNode, margin: f64, position: &mut Position) -> Self {
+        position.offset_y(margin);
+        let fs = node.font_size;
+        let new_node = Node {
+            node_type: NodeType::Text(node),
+            margin: Rectangle::with_values(margin, 0., 0., margin),
+            padding: Rectangle::new(),
+            parent: None,
+            next_sibling: None,
+            children: Vec::new(),
+            position: Position::new_from_existing(position),
+        };
+
+        position.offset_y(fs + margin);
+
+        new_node
+    }
+
     // I took the margins/font sizes from Chrome dev tools.
     // There are still some slight differences but it's very close
 
     pub fn new_heading1(position: &mut Position) -> Self {
         let margin = 10.72;
-        position.offset_y(margin);
+        let heading = TextNode::new_heading1();
 
-        let new_heading = TextNode::new_heading1();
-        let font_size = new_heading.font_size;
-
-        let new_node = Node {
-            node_type: NodeType::Text(new_heading),
-            margin: Rectangle::with_values(margin, 0., 0., margin),
-            padding: Rectangle::new(),
-            parent: None,
-            next_sibling: None,
-            children: Vec::new(),
-            position: Position::new_from_existing(position),
-        };
-
-        position.offset_y(font_size);
-        position.offset_y(margin);
-
-        new_node
+        Node::new_text(heading, margin, position)
     }
 
     pub fn new_heading2(position: &mut Position) -> Self {
         let margin = 9.96;
-        position.offset_y(margin);
+        let heading = TextNode::new_heading2();
 
-        let new_heading = TextNode::new_heading2();
-        let font_size = new_heading.font_size;
-
-        let new_node = Node {
-            node_type: NodeType::Text(new_heading),
-            margin: Rectangle::with_values(margin, 0., 0., margin),
-            padding: Rectangle::new(),
-            parent: None,
-            next_sibling: None,
-            children: Vec::new(),
-            position: Position::new_from_existing(position),
-        };
-
-        position.offset_y(font_size);
-        position.offset_y(margin);
-
-        new_node
+        Node::new_text(heading, margin, position)
     }
 
     pub fn new_heading3(position: &mut Position) -> Self {
         let margin = 9.36;
-        position.offset_y(margin);
+        let heading = TextNode::new_heading3();
 
-        let new_heading = TextNode::new_heading3();
-        let font_size = new_heading.font_size;
-
-        let new_node = Node {
-            node_type: NodeType::Text(new_heading),
-            margin: Rectangle::with_values(margin, 0., 0., margin),
-            padding: Rectangle::new(),
-            parent: None,
-            next_sibling: None,
-            children: Vec::new(),
-            position: Position::new_from_existing(position),
-        };
-
-        position.offset_y(font_size);
-        position.offset_y(margin);
-
-        new_node
+        Node::new_text(heading, margin, position)
     }
 
     pub fn new_heading4(position: &mut Position) -> Self {
         let margin = 10.64;
-        position.offset_y(margin);
+        let heading = TextNode::new_heading4();
 
-        let new_heading = TextNode::new_heading4();
-        let font_size = new_heading.font_size;
-
-        let new_node = Node {
-            node_type: NodeType::Text(new_heading),
-            margin: Rectangle::with_values(margin, 0., 0., margin),
-            padding: Rectangle::new(),
-            parent: None,
-            next_sibling: None,
-            children: Vec::new(),
-            position: Position::new_from_existing(position),
-        };
-
-        position.offset_y(font_size);
-        position.offset_y(margin);
-
-        new_node
+        Node::new_text(heading, margin, position)
     }
 
     pub fn new_heading5(position: &mut Position) -> Self {
         let margin = 11.089;
-        position.offset_y(margin);
+        let heading = TextNode::new_heading5();
 
-        let new_heading = TextNode::new_heading5();
-        let font_size = new_heading.font_size;
-
-        let new_node = Node {
-            node_type: NodeType::Text(new_heading),
-            margin: Rectangle::with_values(margin, 0., 0., margin),
-            padding: Rectangle::new(),
-            parent: None,
-            next_sibling: None,
-            children: Vec::new(),
-            position: Position::new_from_existing(position),
-        };
-
-        position.offset_y(font_size);
-        position.offset_y(margin);
-
-        new_node
+        Node::new_text(heading, margin, position)
     }
 
     pub fn new_heading6(position: &mut Position) -> Self {
         let margin = 12.489;
-        position.offset_y(margin);
+        let heading = TextNode::new_heading6();
 
-        let new_heading = TextNode::new_heading6();
-        let font_size = new_heading.font_size;
-
-        let new_node = Node {
-            node_type: NodeType::Text(new_heading),
-            margin: Rectangle::with_values(margin, 0., 0., margin),
-            padding: Rectangle::new(),
-            parent: None,
-            next_sibling: None,
-            children: Vec::new(),
-            position: Position::new_from_existing(position),
-        };
-
-        position.offset_y(font_size);
-        position.offset_y(margin);
-
-        new_node
+        Node::new_text(heading, margin, position)
     }
 
     pub fn new_paragraph(position: &mut Position) -> Self {
         let margin = 8.;
-        position.offset_y(margin);
+        let paragraph = TextNode::new_paragraph();
 
-        let new_paragraph = TextNode::new_paragraph();
-        let font_size = new_paragraph.font_size;
-
-        let new_node = Node {
-            node_type: NodeType::Text(new_paragraph),
-            margin: Rectangle::with_values(margin, 0., 0., margin),
-            padding: Rectangle::new(),
-            parent: None,
-            next_sibling: None,
-            children: Vec::new(),
-            position: Position::new_from_existing(position),
-        };
-
-        position.offset_y(font_size);
-        position.offset_y(margin);
-
-        new_node
+        Node::new_text(paragraph, margin, position)
     }
 
     pub fn add_child(&mut self, child: &Rc<RefCell<Node>>) {

--- a/src/render_tree.rs
+++ b/src/render_tree.rs
@@ -1,15 +1,14 @@
-pub mod properties;
-pub mod text;
-pub mod util;
-
 use std::borrow::BorrowMut;
 use std::{cell::RefCell, rc::Rc};
 
+use crate::html5::node::NodeData;
 use crate::html5::parser::document;
 use crate::html5::parser::document::{Document, DocumentHandle};
-
-use crate::html5::node::NodeData;
 use crate::render_tree::{properties::Rectangle, text::TextNode};
+
+pub mod properties;
+pub mod text;
+pub mod util;
 
 /// The position of the render cursor used to determine where
 /// to draw an object
@@ -103,51 +102,21 @@ impl RenderTree {
             if let Some(current_node) = doc_read.get_node_by_id(current_node_id) {
                 match &current_node.data {
                     NodeData::Element(element) => {
-                        match element.name.as_str() {
-                            "h1" => {
-                                let new_node =
-                                    Rc::new(RefCell::new(Node::new_heading1(&mut self.position)));
-                                util::add_text_node(&reference_element, &new_node);
-                                reference_element = Rc::clone(&new_node);
-                            }
-                            "h2" => {
-                                let new_node =
-                                    Rc::new(RefCell::new(Node::new_heading2(&mut self.position)));
-                                util::add_text_node(&reference_element, &new_node);
-                                reference_element = Rc::clone(&new_node);
-                            }
-                            "h3" => {
-                                let new_node =
-                                    Rc::new(RefCell::new(Node::new_heading3(&mut self.position)));
-                                util::add_text_node(&reference_element, &new_node);
-                                reference_element = Rc::clone(&new_node);
-                            }
-                            "h4" => {
-                                let new_node =
-                                    Rc::new(RefCell::new(Node::new_heading4(&mut self.position)));
-                                util::add_text_node(&reference_element, &new_node);
-                                reference_element = Rc::clone(&new_node);
-                            }
-                            "h5" => {
-                                let new_node =
-                                    Rc::new(RefCell::new(Node::new_heading5(&mut self.position)));
-                                util::add_text_node(&reference_element, &new_node);
-                                reference_element = Rc::clone(&new_node);
-                            }
-                            "h6" => {
-                                let new_node =
-                                    Rc::new(RefCell::new(Node::new_heading6(&mut self.position)));
-                                util::add_text_node(&reference_element, &new_node);
-                                reference_element = Rc::clone(&new_node);
-                            }
-                            "p" => {
-                                let new_node =
-                                    Rc::new(RefCell::new(Node::new_paragraph(&mut self.position)));
-                                util::add_text_node(&reference_element, &new_node);
-                                reference_element = Rc::clone(&new_node);
-                            }
-                            _ => { /* add more here, for now ignore */ }
-                        }
+                        let new_node = match element.name.as_str() {
+                            "h1" => Node::new_heading1,
+                            "h2" => Node::new_heading2,
+                            "h3" => Node::new_heading3,
+                            "h4" => Node::new_heading4,
+                            "h5" => Node::new_heading5,
+                            "h6" => Node::new_heading6,
+                            "p" => Node::new_paragraph,
+                            _ => todo!(), /* add more here, for now ignore */
+                        }(&mut self.position);
+
+                        let new_node = Rc::new(RefCell::new(new_node));
+
+                        util::add_text_node(&reference_element, &new_node);
+                        reference_element = Rc::clone(&new_node);
                     }
                     NodeData::Text(text) => {
                         let mut mut_element_ref = reference_element.as_ref().borrow_mut();

--- a/src/render_tree/text.rs
+++ b/src/render_tree/text.rs
@@ -16,40 +16,40 @@ impl TextNode {
         NOTE: I got the default font sizes from https://stackoverflow.com/a/70720104
     */
 
-    fn new(fs: f64) -> Self {
+    fn new(fs: f64, bold: bool) -> Self {
         Self {
             value: "".to_owned(),
             font: DEFAULT_FONT.to_owned(),
             font_size: fs,
-            is_bold: false,
+            is_bold: bold,
         }
     }
 
     pub fn new_heading1() -> Self {
-        TextNode::new(37.)
+        TextNode::new(37., true)
     }
 
     pub fn new_heading2() -> Self {
-        TextNode::new(27.5)
+        TextNode::new(27.5, true)
     }
 
     pub fn new_heading3() -> Self {
-        TextNode::new(21.5)
+        TextNode::new(21.5,true)
     }
 
     pub fn new_heading4() -> Self {
-        TextNode::new(18.5)
+        TextNode::new(18.5,true)
     }
 
     pub fn new_heading5() -> Self {
-        TextNode::new(15.5)
+        TextNode::new(15.5,true)
     }
 
     pub fn new_heading6() -> Self {
-        TextNode::new(12.)
+        TextNode::new(12.,true)
     }
 
     pub fn new_paragraph() -> Self {
-        TextNode::new(18.5)
+        TextNode::new(18.5,false)
     }
 }

--- a/src/render_tree/text.rs
+++ b/src/render_tree/text.rs
@@ -15,66 +15,41 @@ impl TextNode {
     /*
         NOTE: I got the default font sizes from https://stackoverflow.com/a/70720104
     */
-    pub fn new_heading1() -> Self {
+
+    fn new(fs: f64) -> Self {
         Self {
             value: "".to_owned(),
             font: DEFAULT_FONT.to_owned(),
-            font_size: 37.,
-            is_bold: true,
+            font_size: fs,
+            is_bold: false,
         }
+    }
+
+    pub fn new_heading1() -> Self {
+        TextNode::new(37.)
     }
 
     pub fn new_heading2() -> Self {
-        Self {
-            value: "".to_owned(),
-            font: DEFAULT_FONT.to_owned(),
-            font_size: 27.5,
-            is_bold: true,
-        }
+        TextNode::new(27.5)
     }
 
     pub fn new_heading3() -> Self {
-        Self {
-            value: "".to_owned(),
-            font: DEFAULT_FONT.to_owned(),
-            font_size: 21.5,
-            is_bold: true,
-        }
+        TextNode::new(21.5)
     }
 
     pub fn new_heading4() -> Self {
-        Self {
-            value: "".to_owned(),
-            font: DEFAULT_FONT.to_owned(),
-            font_size: 18.5,
-            is_bold: true,
-        }
+        TextNode::new(18.5)
     }
 
     pub fn new_heading5() -> Self {
-        Self {
-            value: "".to_owned(),
-            font: DEFAULT_FONT.to_owned(),
-            font_size: 15.5,
-            is_bold: true,
-        }
+        TextNode::new(15.5)
     }
 
     pub fn new_heading6() -> Self {
-        Self {
-            value: "".to_owned(),
-            font: DEFAULT_FONT.to_owned(),
-            font_size: 12.,
-            is_bold: true,
-        }
+        TextNode::new(12.)
     }
 
     pub fn new_paragraph() -> Self {
-        Self {
-            value: "".to_owned(),
-            font: DEFAULT_FONT.to_owned(),
-            font_size: 18.5,
-            is_bold: false,
-        }
+        TextNode::new(18.5)
     }
 }

--- a/src/render_tree/text.rs
+++ b/src/render_tree/text.rs
@@ -34,22 +34,22 @@ impl TextNode {
     }
 
     pub fn new_heading3() -> Self {
-        TextNode::new(21.5,true)
+        TextNode::new(21.5, true)
     }
 
     pub fn new_heading4() -> Self {
-        TextNode::new(18.5,true)
+        TextNode::new(18.5, true)
     }
 
     pub fn new_heading5() -> Self {
-        TextNode::new(15.5,true)
+        TextNode::new(15.5, true)
     }
 
     pub fn new_heading6() -> Self {
-        TextNode::new(12.,true)
+        TextNode::new(12., true)
     }
 
     pub fn new_paragraph() -> Self {
-        TextNode::new(18.5,false)
+        TextNode::new(18.5, false)
     }
 }


### PR DESCRIPTION
This tries to get rid of most of the duplicate code in the creation of text nodes for the RenderTree. For the discussion see #272