### PR TITLE
Http request / response objects and initial API endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +244,16 @@ checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -289,6 +343,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cookie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
+dependencies = [
+ "aes-gcm",
+ "base64",
+ "hkdf",
+ "hmac",
+ "rand",
+ "sha2",
+ "subtle",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -416,6 +532,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "domain-lookup-tree"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +574,12 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -461,6 +603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "flate2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,10 +619,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.0"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -501,6 +670,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+
+[[package]]
 name = "futures-task"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,10 +688,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -528,6 +715,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -544,16 +741,19 @@ dependencies = [
  "clap",
  "cli-table",
  "colored",
+ "cookie",
  "criterion",
  "derive_more",
  "domain-lookup-tree",
  "hickory-resolver",
+ "http 1.0.0",
  "lazy_static",
  "log",
  "nom",
  "nom_locate",
  "phf",
  "regex",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -566,9 +766,29 @@ dependencies = [
  "thiserror",
  "typed-arena",
  "ureq",
+ "url",
  "uuid",
  "walkdir",
  "wildmatch",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.11",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -576,6 +796,12 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -602,7 +828,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna",
+ "idna 0.4.0",
  "ipnet",
  "once_cell",
  "rand",
@@ -635,6 +861,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +887,88 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi",
+]
+
+[[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.11",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -656,12 +982,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.5",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -779,6 +1134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +1163,24 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -875,6 +1254,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
@@ -989,6 +1418,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1140,6 +1581,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.11",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -1230,6 +1709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1731,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1280,6 +1791,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1326,6 +1860,16 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -1380,6 +1924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1949,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1553,9 +2137,39 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -1589,10 +2203,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
@@ -1628,6 +2254,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,12 +2287,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -1676,6 +2312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +2331,15 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1720,6 +2371,18 @@ dependencies = [
  "quote",
  "syn 2.0.38",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,22 +360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,15 +539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,12 +549,6 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -603,12 +572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
-
-[[package]]
 name = "flate2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,21 +586,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -670,12 +618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
-
-[[package]]
 name = "futures-task"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,9 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -746,14 +686,13 @@ dependencies = [
  "derive_more",
  "domain-lookup-tree",
  "hickory-resolver",
- "http 1.0.0",
+ "http",
  "lazy_static",
  "log",
  "nom",
  "nom_locate",
  "phf",
  "regex",
- "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -773,35 +712,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.11",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -891,17 +805,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
@@ -909,66 +812,6 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http 0.2.11",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.11",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.4.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -992,16 +835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,7 +849,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.5",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1134,12 +967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,24 +990,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1258,50 +1067,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
-dependencies = [
- "bitflags 2.4.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.96"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1581,44 +1346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "reqwest"
-version = "0.11.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.11",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,15 +1436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,29 +1449,6 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1788,18 +1483,6 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1860,16 +1543,6 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "socket2"
@@ -1949,40 +1622,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2137,39 +1776,9 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -2201,12 +1810,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typed-arena"
@@ -2312,12 +1915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,15 +1928,6 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -2371,18 +1959,6 @@ dependencies = [
  "quote",
  "syn 2.0.38",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ simple_logger = "4.2.0"
 shared_singleton = "0.1.0"
 testing_logger = "0.1.1"
 cookie = { version = "0.18.0", features = ["secure", "private"] }
-reqwest = { version = "0.11.22", features = ["blocking"] }
 http = "1.0.0"
 url = "2.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ hickory-resolver = "0.24.0"
 simple_logger = "4.2.0"
 shared_singleton = "0.1.0"
 testing_logger = "0.1.1"
+cookie = { version = "0.18.0", features = ["secure", "private"] }
+reqwest = { version = "0.11.22", features = ["blocking"] }
+http = "1.0.0"
+url = "2.5.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -275,6 +275,14 @@ impl CharIterator {
         result
     }
 
+    /// Read directly from bytes
+    pub fn read_from_bytes(&mut self, bytes: &[u8], e: Option<Encoding>) -> io::Result<()> {
+        self.u8_buffer = bytes.to_vec();
+        self.force_set_encoding(e.unwrap_or(Encoding::UTF8));
+        self.reset();
+        Ok(())
+    }
+
     /// Populates the current buffer with the contents of given file f
     pub fn read_from_file(&mut self, mut f: File, e: Option<Encoding>) -> io::Result<()> {
         // First we read the u8 bytes into a buffer

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -12,7 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A DNS entry is a mapping of a domain to zero or more IP address mapping
 #[derive(Default, Clone, Debug, PartialEq)]
-struct DnsEntry {
+pub struct DnsEntry {
     // domain name
     domain: String,
     // // Ip type that is stored in this entry (could be Ipv4, IPv6 or Both)
@@ -103,7 +103,7 @@ trait DnsCache {
     fn flush_entry(&mut self, domain: &str);
 }
 
-struct Dns {
+pub struct Dns {
     resolvers: Vec<Box<dyn DnsResolver>>,
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,187 @@
+use crate::bytes::{CharIterator, Confidence, Encoding};
+use crate::dns::ResolveType;
+use crate::html5::parser::document::{Document, DocumentBuilder, DocumentHandle};
+use crate::html5::parser::Html5Parser;
+use crate::net::errors::Error;
+use crate::net::http::headers::Headers;
+use crate::net::http::request::Request;
+use crate::net::http::response::Response;
+use crate::timing::{Timing, TimingTable};
+use crate::types::ParseError;
+use cookie::CookieJar;
+use core::fmt::Debug;
+use core::str::FromStr;
+use reqwest::header::HeaderName;
+use reqwest::Method;
+use url::Url;
+
+/// Response that is returned from the fetch function
+pub struct FetchResponse {
+    /// Request that has been send
+    pub request: Request,
+    /// Response that has been received
+    pub response: Response,
+    /// Document tree that is made from the response
+    pub document: DocumentHandle,
+    /// Parse errors that occurred while parsing the document tree
+    pub parse_errors: Vec<ParseError>,
+    /// Rendertree that is generated from the document tree and css tree
+    pub render_tree: String,
+    /// Timing table that contains all the timings
+    pub timings: TimingTable,
+}
+
+impl Debug for FetchResponse {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "Request:")?;
+        writeln!(f, "{}", self.request)?;
+        writeln!(f, "Response:")?;
+        writeln!(f, "{}", self.response)?;
+        writeln!(f, "Document tree:")?;
+        writeln!(f, "{}", self.document)?;
+        writeln!(f, "Parse errors:")?;
+        for error in &self.parse_errors {
+            writeln!(f, "  ({}:{}) {}", error.line, error.col, error.message)?;
+        }
+        writeln!(f, "Render tree:")?;
+        writeln!(f, "{}", self.render_tree)?;
+        writeln!(f, "Timings:")?;
+        writeln!(f, "{}", self.timings)?;
+
+        Ok(())
+    }
+}
+
+fn fetch_url(
+    method: &str,
+    url: &str,
+    headers: Headers,
+    cookies: CookieJar,
+) -> Result<FetchResponse, Error> {
+    let mut http_req = Request::new(method, url, "HTTP/1.1");
+    http_req.headers = headers.clone();
+    http_req.cookies = cookies.clone();
+
+    let parts = Url::parse(url);
+    if parts.is_err() {
+        return Err(Error::Generic(format!("Failed to parse URL: {}", url)));
+    }
+
+    let mut fetch_response = FetchResponse {
+        request: http_req,
+        response: Response::new(),
+        document: DocumentBuilder::new_document(),
+        parse_errors: vec![],
+        render_tree: String::new(),
+        timings: TimingTable::default(),
+    };
+
+    // For now, we do a DNS lookup here. We don't use this information yet, but it allows us to
+    // measure the DNS lookup time.
+    fetch_response.timings.start(Timing::DnsLookup);
+
+    let mut resolver = crate::dns::Dns::new();
+    let res = resolver.resolve(parts.unwrap().host_str().unwrap(), ResolveType::Ipv4);
+    if res.is_err() {
+        return Err(Error::Generic(format!("Failed to resolve domain: {}", url)));
+    }
+
+    fetch_response.timings.end(Timing::DnsLookup);
+
+    // Fetch the HTML document from the site
+    fetch_response.timings.start(Timing::ContentTransfer);
+
+    let m = Method::from_str(method).unwrap();
+    let u = Url::parse(url).unwrap();
+    let mut req = reqwest::blocking::Request::new(m, u);
+    for (key, value) in headers.sorted() {
+        req.headers_mut()
+            .insert(HeaderName::from_str(key).unwrap(), value.parse().unwrap());
+    }
+
+    match reqwest::blocking::Client::new().execute(req) {
+        Ok(resp) => {
+            fetch_response.response = Response::new();
+            fetch_response.response.status = resp.status().as_u16();
+            fetch_response.response.version = format!("{:?}", resp.version());
+            for (key, value) in resp.headers().iter() {
+                fetch_response
+                    .response
+                    .headers
+                    .set(key.as_str(), value.to_str().unwrap());
+            }
+            // for cookie in resp.cookies() {
+            //     fetch_response.response.cookies.insert(cookie.name().to_string(), cookie.value().to_string());
+            // }
+            fetch_response.response.body = resp.bytes().unwrap().to_vec();
+        }
+        Err(e) => {
+            return Err(Error::Generic(format!("Failed to fetch URL: {}", e)));
+        }
+    }
+    fetch_response.timings.end(Timing::ContentTransfer);
+
+    println!("resp: {:?}", fetch_response.response);
+
+    fetch_response.timings.start(Timing::HtmlParse);
+
+    let mut chars = CharIterator::new();
+    let _ = chars.read_from_bytes(&fetch_response.response.body, Some(Encoding::UTF8));
+    chars.set_confidence(Confidence::Certain);
+    fetch_response.document = DocumentBuilder::new_document();
+
+    match Html5Parser::parse_document(&mut chars, Document::clone(&fetch_response.document), None) {
+        Ok(parse_errors) => {
+            fetch_response.parse_errors = parse_errors;
+        }
+        Err(e) => {
+            return Err(Error::Generic(format!("Failed to parse HTML: {}", e)));
+        }
+    }
+    fetch_response.timings.end(Timing::HtmlParse);
+
+    Ok(fetch_response)
+
+    // reqwest::ClientBuilder::new()
+    //     .execute()
+    //
+    //     .execute(resp.request)
+    //     .get(url)
+    //     .headers(headers.all())
+    //     .cookie(cookies)
+    //     .send()?
+
+    // resp = reqwest::blocking::Client::new()
+    //     .execute(resp.request)
+    //     .get(url)
+    //     .headers(headers.all())
+    //     .cookie(cookies)
+    //     .send()
+    //
+    // resp = reqwest::blocking::Client::new()
+    //     .get(url)
+    //     .headers(headers.all())
+    //     .cookie(cookies)
+    //     .send()?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const USER_AGENT: &str = "Mozilla/5.0 (compatible; gosub/0.1; +https://gosub.io)";
+
+    #[test]
+    fn test_fetch_url() {
+        let url = "https://gosub.io/";
+        let mut headers = Headers::new();
+        headers.set("User-Agent", USER_AGENT);
+        let cookies = CookieJar::new();
+
+        let resp = fetch_url("GET", url, headers, cookies);
+        assert!(resp.is_ok());
+
+        let resp = resp.unwrap();
+        print!("{:?}", resp);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,10 @@ pub mod types;
 pub mod config;
 #[allow(dead_code)]
 mod dns;
+
+#[allow(dead_code)]
+mod engine;
+#[allow(dead_code)]
+mod net;
+#[allow(dead_code)]
+mod timing;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,2 @@
+pub mod errors;
+pub mod http;

--- a/src/net/errors.rs
+++ b/src/net/errors.rs
@@ -1,0 +1,8 @@
+//! Error results that can be returned from the engine
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("net: generic error: {0}")]
+    Generic(String),
+}

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -1,0 +1,3 @@
+pub mod headers;
+pub mod request;
+pub mod response;

--- a/src/net/http/headers.rs
+++ b/src/net/http/headers.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+
+#[derive(Default, Debug, Clone)]
+pub struct Headers {
+    headers: HashMap<String, String>,
+}
+
+impl Headers {
+    pub fn new() -> Headers {
+        Headers {
+            headers: HashMap::new(),
+        }
+    }
+
+    pub fn set(&mut self, key: &str, value: &str) {
+        self.headers.insert(key.to_string(), value.to_string());
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.headers.get(key)
+    }
+
+    /// Returns all the header entries. Note that there is no ordering in here!
+    pub fn all(&self) -> &HashMap<String, String> {
+        &self.headers
+    }
+
+    pub fn sorted(&self) -> Vec<(&String, &String)> {
+        let mut sorted = self.headers.iter().collect::<Vec<_>>();
+        sorted.sort_by(|a, b| a.0.cmp(b.0));
+        sorted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_headers() {
+        let mut headers = Headers::new();
+
+        headers.set("Content-Type", "application/json");
+        assert_eq!(headers.get("Content-Type").unwrap(), "application/json");
+
+        headers.set("Content-Type", "text/html");
+        assert_eq!(headers.get("Content-Type").unwrap(), "text/html");
+        assert_eq!(headers.all().len(), 1);
+    }
+}

--- a/src/net/http/request.rs
+++ b/src/net/http/request.rs
@@ -1,0 +1,93 @@
+use crate::net::http::headers::Headers;
+use cookie::CookieJar;
+use core::fmt::{Display, Formatter};
+
+pub struct Request {
+    pub method: String,
+    pub uri: String,
+    pub version: String,
+    pub headers: Headers,
+    pub cookies: CookieJar,
+    pub body: Vec<u8>,
+}
+
+impl Request {
+    pub(crate) fn new(method: &str, uri: &str, version: &str) -> Self {
+        Self {
+            method: method.to_string(),
+            uri: uri.to_string(),
+            version: version.to_string(),
+            headers: Headers::default(),
+            cookies: CookieJar::default(),
+            body: vec![],
+        }
+    }
+
+    pub fn headers(&mut self, headers: Headers) {
+        self.headers = headers;
+    }
+
+    pub fn cookies(&mut self, cookies: CookieJar) {
+        self.cookies = cookies;
+    }
+}
+
+impl Display for Request {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "{} {} {}", self.method, self.uri, self.version)?;
+        writeln!(f, "Headers:")?;
+        for (key, value) in self.headers.sorted() {
+            writeln!(f, "  {}: {}", key, value)?;
+        }
+        writeln!(f, "Cookies:")?;
+        let mut sorted_cookies = self.cookies.iter().collect::<Vec<_>>();
+        sorted_cookies.sort_by(|a, b| a.name().cmp(b.name()));
+        for cookie in sorted_cookies {
+            writeln!(f, "  {}", cookie)?;
+        }
+        writeln!(f, "Body: {} bytes", self.body.len())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cookie::Cookie;
+
+    #[test]
+    fn test_request() {
+        let mut req = Request::new("GET", "/", "HTTP/1.1");
+        req.headers(Headers::new());
+        req.cookies(CookieJar::new());
+
+        req.headers.set("Content-Type", "application/json");
+        req.cookies.add(Cookie::new("qux", "wok"));
+        req.cookies.add(Cookie::new("foo", "bar"));
+        req.headers.set("Accept", "text/html");
+        req.headers.set("Accept-Encoding", "gzip, deflate, br");
+
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.uri, "/");
+        assert_eq!(req.version, "HTTP/1.1");
+        assert_eq!(req.headers.all().len(), 3);
+        assert_eq!(req.cookies.iter().count(), 2);
+    }
+
+    #[test]
+    fn test_request_display() {
+        let mut req = Request::new("GET", "/", "HTTP/1.1");
+        req.headers(Headers::new());
+        req.cookies(CookieJar::new());
+
+        req.cookies.add(Cookie::new("foo", "bar"));
+        req.cookies.add(Cookie::new("qux", "wok"));
+        req.headers.set("Content-Type", "application/json");
+        req.headers.set("Accept", "text/html");
+        req.headers.set("Accept-Encoding", "gzip, deflate, br");
+
+        let s = format!("{}", req);
+        assert_eq!(s, "GET / HTTP/1.1\nHeaders:\n  Accept: text/html\n  Accept-Encoding: gzip, deflate, br\n  Content-Type: application/json\nCookies:\n  foo=bar\n  qux=wok\nBody: 0 bytes\n");
+    }
+}

--- a/src/net/http/response.rs
+++ b/src/net/http/response.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct Response {
     pub status: u16,
+    pub status_text: String,
     pub version: String,
     pub headers: Headers,
     pub cookies: HashMap<String, String>,
@@ -15,6 +16,7 @@ impl Response {
     pub(crate) fn new() -> Response {
         Self {
             status: 0,
+            status_text: "".to_string(),
             version: "HTTP/1.1".to_string(),
             headers: Default::default(),
             cookies: Default::default(),

--- a/src/net/http/response.rs
+++ b/src/net/http/response.rs
@@ -1,0 +1,64 @@
+use crate::net::http::headers::Headers;
+use core::fmt::{Display, Formatter};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Response {
+    pub status: u16,
+    pub version: String,
+    pub headers: Headers,
+    pub cookies: HashMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+impl Response {
+    pub(crate) fn new() -> Response {
+        Self {
+            status: 0,
+            version: "HTTP/1.1".to_string(),
+            headers: Default::default(),
+            cookies: Default::default(),
+            body: vec![],
+        }
+    }
+}
+
+impl Display for Response {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "HTTP/1.1 {}", self.status)?;
+        writeln!(f, "Headers:")?;
+        for (key, value) in self.headers.all() {
+            writeln!(f, "  {}: {}", key, value)?;
+        }
+        writeln!(f, "Cookies:")?;
+        for (key, value) in &self.cookies {
+            writeln!(f, "  {}: {}", key, value)?;
+        }
+        writeln!(f, "Body: {} bytes", self.body.len())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response() {
+        let mut response = Response::new();
+
+        let s = format!("{}", response);
+        assert_eq!(s, "HTTP/1.1 0\nHeaders:\nCookies:\nBody: 0 bytes\n");
+
+        response.status = 200;
+        response.headers.set("Content-Type", "application/json");
+        response
+            .cookies
+            .insert("session".to_string(), "1234567890".to_string());
+        response.body = b"Hello, world!".to_vec();
+
+        let s = format!("{}", response);
+        assert_eq!(s, "HTTP/1.1 200\nHeaders:\n  Content-Type: application/json\nCookies:\n  session: 1234567890\nBody: 13 bytes\n");
+    }
+}

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,0 +1,183 @@
+use core::fmt::{Display, Formatter};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub enum Timing {
+    DnsLookup,
+    TcpConnection,
+    TlsHandshake,
+    ServerProcessing,
+    ContentTransfer,
+    HtmlParse,
+    CssParse,
+    JsParse,
+    RenderTree,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Timer {
+    start: u64,
+    end: u64,
+}
+
+impl Timer {
+    pub fn new() -> Timer {
+        Timer { start: 0, end: 0 }
+    }
+
+    pub fn start(&mut self) {
+        let current_time = SystemTime::now();
+        let duration_since_epoch = current_time
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let milliseconds_since_epoch =
+            duration_since_epoch.as_secs() * 1000 + u64::from(duration_since_epoch.subsec_millis());
+
+        self.start = milliseconds_since_epoch;
+    }
+
+    pub fn end(&mut self) {
+        let current_time = SystemTime::now();
+        let duration_since_epoch = current_time
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let milliseconds_since_epoch =
+            duration_since_epoch.as_secs() * 1000 + u64::from(duration_since_epoch.subsec_millis());
+
+        self.end = milliseconds_since_epoch;
+    }
+
+    pub fn duration(&self) -> u64 {
+        self.end - self.start
+    }
+}
+
+/// Timing information for a single request. Timing is measured in milliseconds.
+#[derive(Default, Debug, Clone)]
+pub struct TimingTable {
+    /// Time spent making DNS queries.
+    pub dns_lookup: Timer,
+    /// Time spent establishing TCP connection.
+    pub tcp_connection: Timer,
+    /// Time spent performing TLS handshake.
+    pub tls_handshake: Timer,
+    /// Time spent sending HTTP request.
+    pub server_processing: Timer,
+    /// Time spent waiting for HTTP response.
+    pub content_transfer: Timer,
+    /// Time spent parsing HTML.
+    pub html_parse: Timer,
+    /// Time spent parsing CSS.
+    pub css_parse: Timer,
+    /// Time spent parsing JS.
+    pub js_parse: Timer,
+    /// Time spent generating render_tree
+    pub render_tree: Timer,
+}
+
+impl Display for TimingTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "DNS lookup:        {:6}ms", self.dns_lookup.duration())?;
+        writeln!(
+            f,
+            "TCP connection:    {:6}ms",
+            self.tcp_connection.duration()
+        )?;
+        writeln!(
+            f,
+            "TLS handshake:     {:6}ms",
+            self.tls_handshake.duration()
+        )?;
+        writeln!(
+            f,
+            "Server processing: {:6}ms",
+            self.server_processing.duration()
+        )?;
+        writeln!(
+            f,
+            "Content transfer:  {:6}ms",
+            self.content_transfer.duration()
+        )?;
+        writeln!(f, "HTML parse:        {:6}ms", self.html_parse.duration())?;
+        writeln!(f, "CSS parse:         {:6}ms", self.css_parse.duration())?;
+        writeln!(f, "JS parse:          {:6}ms", self.js_parse.duration())?;
+        writeln!(f, "Render tree:       {:6}ms", self.render_tree.duration())?;
+
+        Ok(())
+    }
+}
+
+impl TimingTable {
+    /// Starts a timing table, setting the start time to the current time.
+    pub fn start(&mut self, timing: Timing) {
+        match timing {
+            Timing::DnsLookup => self.dns_lookup.start(),
+            Timing::TcpConnection => self.tcp_connection.start(),
+            Timing::TlsHandshake => self.tls_handshake.start(),
+            Timing::ServerProcessing => self.server_processing.start(),
+            Timing::ContentTransfer => self.content_transfer.start(),
+            Timing::HtmlParse => self.html_parse.start(),
+            Timing::CssParse => self.css_parse.start(),
+            Timing::JsParse => self.js_parse.start(),
+            Timing::RenderTree => self.render_tree.start(),
+        }
+    }
+
+    pub fn end(&mut self, timing: Timing) {
+        match timing {
+            Timing::DnsLookup => self.dns_lookup.end(),
+            Timing::TcpConnection => self.tcp_connection.end(),
+            Timing::TlsHandshake => self.tls_handshake.end(),
+            Timing::ServerProcessing => self.server_processing.end(),
+            Timing::ContentTransfer => self.content_transfer.end(),
+            Timing::HtmlParse => self.html_parse.end(),
+            Timing::CssParse => self.css_parse.end(),
+            Timing::JsParse => self.js_parse.end(),
+            Timing::RenderTree => self.render_tree.end(),
+        }
+    }
+
+    pub fn duration(&self, timing: Timing) -> u64 {
+        match timing {
+            Timing::DnsLookup => self.dns_lookup.duration(),
+            Timing::TcpConnection => self.tcp_connection.duration(),
+            Timing::TlsHandshake => self.tls_handshake.duration(),
+            Timing::ServerProcessing => self.server_processing.duration(),
+            Timing::ContentTransfer => self.content_transfer.duration(),
+            Timing::HtmlParse => self.html_parse.duration(),
+            Timing::CssParse => self.css_parse.duration(),
+            Timing::JsParse => self.js_parse.duration(),
+            Timing::RenderTree => self.render_tree.duration(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+
+    #[test]
+    fn test_timing_defaults() {
+        let timing_table = TimingTable::default();
+
+        assert_eq!(0, timing_table.duration(Timing::DnsLookup));
+        assert_eq!(0, timing_table.duration(Timing::TcpConnection));
+        assert_eq!(0, timing_table.duration(Timing::RenderTree));
+    }
+
+    fn test_timings() {
+        let mut timingtable = TimingTable::default();
+
+        timingtable.start(Timing::DnsLookup);
+        timingtable.start(Timing::TcpConnection);
+        sleep(std::time::Duration::from_millis(150));
+        timingtable.end(Timing::DnsLookup);
+        sleep(std::time::Duration::from_millis(10));
+        timingtable.end(Timing::TcpConnection);
+
+        assert!(timingtable.duration(Timing::DnsLookup) > 100);
+        assert!(
+            timingtable.duration(Timing::TcpConnection) > timingtable.duration(Timing::DnsLookup)
+        );
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,12 @@ pub enum Error {
 
     #[error("dns: domain not found")]
     DnsDomainNotFound,
+
+    #[error("there was a problem: {0}")]
+    Generic(String),
+
+    #[error("failed to parse url: {0}")]
+    Url(#[from] url::ParseError),
 }
 
 /// Result that can be returned which holds either T or an Error


### PR DESCRIPTION
Starting on a network layer and engine api entrypoint.  We use a custom http request/response since the crates found are a bit overkill for now.  This PR adds a simple http response and request objects that are used for returning in the gosub engine API to the user-agents.

The current api consists of a single function:
```
fn fetch_url(
    method: &str,
    url: &str,
    headers: Headers,
    cookies: CookieJar,
) -> Result<FetchResponse, Error> {
```

That will retrieve the URL and returns a fetch response which is a collection of information (request send, response received, document tree, render tree (later), parser errors and timings.  

This is not a finished system, but a simple start. 