### PR TITLE
expose node position in C API

### DIFF
--- a/crates/gosub-bindings/include/nodes.h
+++ b/crates/gosub-bindings/include/nodes.h
@@ -13,8 +13,14 @@ void render_tree_node_free(struct node_t **node);
 
 enum node_type_e { NODE_TYPE_ROOT = 0u, NODE_TYPE_TEXT };
 
+struct position_t {
+  double x;
+  double y;
+};
+
 struct node_t {
   enum node_type_e type;
+  struct position_t position;
   union data {
     bool root;               // NODE_TYPE_ROOT
     struct node_text_t text; // NODE_TYPE_TEXT
@@ -22,6 +28,8 @@ struct node_t {
 };
 
 struct node_t *render_tree_node_init();
+double render_tree_node_get_x(const struct node_t *node);
+double render_tree_node_get_y(const struct node_t *node);
 void render_tree_node_free_data(struct node_t *node);
 void render_tree_node_free(struct node_t **node);
 

--- a/crates/gosub-bindings/include/nodes/text.h
+++ b/crates/gosub-bindings/include/nodes/text.h
@@ -2,10 +2,13 @@
 #define GOSUB_API_NODES_TEXT_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 struct node_t;
 
 struct node_text_t {
+  // this tag is not used but is required to map properly from Rust
+  uint32_t tag;
   char *value;
   char *font;
   double font_size;

--- a/crates/gosub-bindings/src/lib.rs
+++ b/crates/gosub-bindings/src/lib.rs
@@ -4,8 +4,6 @@ use std::ptr;
 
 pub mod wrapper;
 
-use crate::wrapper::text::CTextNode;
-
 use gosub_engine::{
     bytes::{CharIterator, Confidence, Encoding},
     html5::parser::{
@@ -14,6 +12,7 @@ use gosub_engine::{
     },
     render_tree::{Node, NodeType, RenderTree, TreeIterator},
 };
+use wrapper::node::CNode;
 
 /// Initialize a render tree and return an owning pointer to it.
 /// If the HTML fails to parse or the html string fails to be converted to Rust,
@@ -91,12 +90,10 @@ pub unsafe extern "C" fn gosub_render_tree_next_node(
 /// and a mutable pointer owned by the C API to write (copy) the contents
 /// of the read-only pointer into the mutable pointer.
 #[no_mangle]
-pub unsafe extern "C" fn gosub_render_tree_get_node_data(
-    node: *const Node,
-    node_data: *mut CTextNode,
-) {
+pub unsafe extern "C" fn gosub_render_tree_get_node_data(node: *const Node, c_node: *mut CNode) {
+    // Change this to a match when we have more types
     if let NodeType::Text(text_node) = &(*node).node_type {
-        *node_data = CTextNode::from(text_node);
+        (*c_node) = CNode::new_text(&(*node).position, text_node);
     }
 }
 

--- a/crates/gosub-bindings/src/nodes.c
+++ b/crates/gosub-bindings/src/nodes.c
@@ -21,6 +21,14 @@ void render_tree_node_free_data(struct node_t *node) {
   }
 }
 
+double render_tree_node_get_x(const struct node_t *node) {
+  return node->position.x;
+}
+
+double render_tree_node_get_y(const struct node_t *node) {
+  return node->position.y;
+}
+
 void render_tree_node_free(struct node_t **node) {
   free(*node);
   *node = NULL;

--- a/crates/gosub-bindings/src/wrapper.rs
+++ b/crates/gosub-bindings/src/wrapper.rs
@@ -1,3 +1,4 @@
+pub mod node;
 pub mod text;
 
 /// Numerical values that map render_tree::NodeType to C

--- a/crates/gosub-bindings/src/wrapper/node.rs
+++ b/crates/gosub-bindings/src/wrapper/node.rs
@@ -1,0 +1,40 @@
+use gosub_engine::render_tree::{text::TextNode, Position};
+
+use crate::wrapper::{text::CTextNode, CNodeType};
+
+#[repr(C, u32)]
+pub enum CNodeData {
+    Root(bool),
+    Text(CTextNode),
+}
+
+#[repr(C)]
+pub struct CNode {
+    pub tag: CNodeType,
+    pub position: Position,
+    pub data: CNodeData,
+}
+
+impl Default for CNode {
+    fn default() -> Self {
+        Self {
+            tag: CNodeType::Root,
+            position: Position::new(),
+            data: CNodeData::Root(true),
+        }
+    }
+}
+
+impl CNode {
+    pub fn new_root() -> Self {
+        Self::default()
+    }
+
+    pub fn new_text(position: &Position, text_node: &TextNode) -> Self {
+        Self {
+            tag: CNodeType::Text,
+            position: (*position).clone(),
+            data: CNodeData::Text(CTextNode::from(text_node)),
+        }
+    }
+}

--- a/crates/gosub-bindings/src/wrapper/text.rs
+++ b/crates/gosub-bindings/src/wrapper/text.rs
@@ -1,4 +1,3 @@
-use crate::wrapper::CNodeType;
 use gosub_engine::render_tree::text::TextNode;
 use std::ffi::c_char;
 use std::ffi::CString;
@@ -7,7 +6,6 @@ use std::ffi::CString;
 /// that converts Rust Strings to owned pointers to pass to the C API.
 #[repr(C)]
 pub struct CTextNode {
-    pub tag: CNodeType,
     pub value: *mut c_char,
     pub font: *mut c_char,
     pub font_size: f64,
@@ -17,7 +15,6 @@ pub struct CTextNode {
 impl From<&TextNode> for CTextNode {
     fn from(text_node: &TextNode) -> Self {
         Self {
-            tag: CNodeType::Text,
             value: CString::new(text_node.value.clone().into_bytes())
                 .expect("Failed to allocate memory for text node value in CTextNode")
                 .into_raw(),

--- a/crates/gosub-bindings/tests/render_tree_test.c
+++ b/crates/gosub-bindings/tests/render_tree_test.c
@@ -23,6 +23,13 @@ int main() {
   node = render_tree_next(&render_tree);
   assert(node->type == NODE_TYPE_ROOT);
 
+  const double tol = 0.00001;
+
+  // TODO: it'll be good at some point in the future to have the
+  // margins to compute the expected_y position instead of manually
+  // doing math. This will make the tests more robust if we change
+  // margins/etc. in the engine.
+
   // <h1>
   node = render_tree_next(&render_tree);
   assert(node->type == NODE_TYPE_TEXT);
@@ -30,6 +37,8 @@ int main() {
   assert(strcmp(node->data.text.font, "Times New Roman") == 0);
   assert(fabs(node->data.text.font_size - 37.0) < 0.00001);
   assert(node->data.text.is_bold == true);
+  assert(fabs(node->position.x - 0.00) < tol);
+  assert(fabs(node->position.y - 10.72) < tol);
 
   // <h2>
   node = render_tree_next(&render_tree);
@@ -38,6 +47,8 @@ int main() {
   assert(strcmp(node->data.text.font, "Times New Roman") == 0);
   assert(fabs(node->data.text.font_size - 27.5) < 0.00001);
   assert(node->data.text.is_bold == true);
+  assert(fabs(node->position.x - 0.00) < tol);
+  assert(fabs(node->position.y - 68.4) < tol);
 
   // <h3>
   node = render_tree_next(&render_tree);
@@ -46,6 +57,8 @@ int main() {
   assert(strcmp(node->data.text.font, "Times New Roman") == 0);
   assert(fabs(node->data.text.font_size - 21.5) < 0.00001);
   assert(node->data.text.is_bold == true);
+  assert(fabs(node->position.x - 0.00) < tol);
+  assert(fabs(node->position.y - 115.22) < tol);
 
   // <h4>
   node = render_tree_next(&render_tree);
@@ -54,6 +67,8 @@ int main() {
   assert(strcmp(node->data.text.font, "Times New Roman") == 0);
   assert(fabs(node->data.text.font_size - 18.5) < 0.00001);
   assert(node->data.text.is_bold == true);
+  assert(fabs(node->position.x - 0.00) < tol);
+  assert(fabs(node->position.y - 156.72) < tol);
 
   // <h5>
   node = render_tree_next(&render_tree);
@@ -62,6 +77,8 @@ int main() {
   assert(strcmp(node->data.text.font, "Times New Roman") == 0);
   assert(fabs(node->data.text.font_size - 15.5) < 0.00001);
   assert(node->data.text.is_bold == true);
+  assert(fabs(node->position.x - 0.00) < tol);
+  assert(fabs(node->position.y - 196.949) < tol);
 
   // <h6>
   node = render_tree_next(&render_tree);
@@ -70,6 +87,8 @@ int main() {
   assert(strcmp(node->data.text.font, "Times New Roman") == 0);
   assert(fabs(node->data.text.font_size - 12.0) < 0.00001);
   assert(node->data.text.is_bold == true);
+  assert(fabs(node->position.x - 0.00) < tol);
+  assert(fabs(node->position.y - 236.027) < tol);
 
   // <p>
   node = render_tree_next(&render_tree);
@@ -78,6 +97,8 @@ int main() {
   assert(strcmp(node->data.text.font, "Times New Roman") == 0);
   assert(fabs(node->data.text.font_size - 18.5) < 0.00001);
   assert(node->data.text.is_bold == false);
+  assert(fabs(node->position.x - 0.00) < tol);
+  assert(fabs(node->position.y - 268.516) < tol);
 
   // end of iterator, last node is free'd
   node = render_tree_next(&render_tree);

--- a/src/render_tree.rs
+++ b/src/render_tree.rs
@@ -13,7 +13,8 @@ pub mod util;
 
 /// The position of the render cursor used to determine where
 /// to draw an object
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
+#[repr(C)]
 pub struct Position {
     pub x: f64,
     pub y: f64,
@@ -25,7 +26,6 @@ impl Position {
         Self { x: 0., y: 0. }
     }
 
-    // TODO: might be more idiomatic to use From trait for this?
     pub fn new_from_existing(position: &Position) -> Self {
         Self {
             x: position.x,


### PR DESCRIPTION
This is a small extension to the C API to expose the node position. After this is merged the user agent can be changed to use positions instead of the default vertical-stack layout