### PR TITLE
add var in C API makefile to change compilation mode

### DIFF
--- a/crates/gosub-bindings/Makefile
+++ b/crates/gosub-bindings/Makefile
@@ -1,16 +1,43 @@
 # "global" compile settings
-INCLUDE_DIR := include
-SRC_DIR := src
-CPPFLAGS := -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/nodes
+
+# compilation mode Release or Debug
+MODE?=Release
+
 CFLAGS_DEBUG := -std=c99 -g -Wall -Wextra -O0
 CFLAGS_RELEASE := -std=c99 -Wall -Wextra -O2
-CFLAGS := $(CFLAGS_DEBUG)
-CC := gcc
-TARGET_DIR := ../../target/debug
 
-LDFLAGS := -L$(TARGET_DIR)
+TARGET_DIR_DEBUG := ../../target/debug
+TARGET_DIR_RELEASE := ../../target/release
+
+ifeq ($(MODE), Release)
+$(info ***** COMPILING IN RELEASE MODE *****)
+CFLAGS = $(CFLAGS_RELEASE)
+TARGET_DIR = $(TARGET_DIR_RELEASE)
+else ifeq ($(MODE), Debug)
+$(info ***** COMPILING IN DEBUG MODE *****)
+CFLAGS = $(CFLAGS_DEBUG)
+TARGET_DIR = $(TARGET_DIR_DEBUG)
+else
+$(warning ***** UNKNOWN MODE. DEFAULTING TO RELEASE MODE *****)
+CFLAGS = $(CFLAGS_RELEASE)
+TARGET_DIR = $(TARGET_DIR_RELEASE)
+endif
+
+CC := gcc
+
+INCLUDE_DIR := include
+SRC_DIR := src
 NODE_SRC_DIR := $(SRC_DIR)/nodes
+
+CPPFLAGS := -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/nodes
+LDFLAGS := -L$(TARGET_DIR)
+
 bindings: # build gosub static library to be used externally
+ifeq ($(MODE), Debug)
+	cargo build
+else
+	cargo build --release
+endif
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $(SRC_DIR)/gosub_api.c $(SRC_DIR)/nodes.c $(NODE_SRC_DIR)/text.c
 	ar rcs libgosub.a gosub_api.o nodes.o text.o
 	rm *.o

--- a/crates/gosub-bindings/README.md
+++ b/crates/gosub-bindings/README.md
@@ -1,5 +1,5 @@
 # Gosub Bindings
-These are the bindings the expose some of Gosub's engine to the world via a C API. Typically these will be used by user agents.
+These are bindings that expose some of Gosub's engine to the world via a C API. Typically these bindings will be used by user agents.
 
 ## Building
 By default, the bindings will be built in release mode. You can modify this by specifying a `MODE` variable:

--- a/crates/gosub-bindings/README.md
+++ b/crates/gosub-bindings/README.md
@@ -1,0 +1,18 @@
+# Gosub Bindings
+These are the bindings the expose some of Gosub's engine to the world via a C API. Typically these will be used by user agents.
+
+## Building
+By default, the bindings will be built in release mode. You can modify this by specifying a `MODE` variable:
+```text
+export MODE=Debug # or MODE=Release (default)
+make bindings
+make test
+```
+
+or alternatively specify it manually (not recommended)
+```text
+make bindings MODE=Debug
+make test MODE=Debug
+```
+
+This approach is not recommended because if you forget to specify it, it will default to release mode and you may be using the wrong version.


### PR DESCRIPTION
This adds a `MODE` variable to the makefile in the `gosub-bindings` to compile in different modes.

By default it will use `Release` mode (for the user agents when they build the bindings) and for development we can switch to `Debug`.

`make bindings` will now also build the crate in the specified mode so we don't have to manually `cargo build` ourselves