### PR TITLE
improve the C API test

### DIFF
--- a/crates/gosub-bindings/include/nodes.h
+++ b/crates/gosub-bindings/include/nodes.h
@@ -7,20 +7,18 @@
 #include <stdlib.h>
 
 #include "nodes/text.h"
+#include "properties.h"
 
 struct node_t *render_tree_node_init();
 void render_tree_node_free(struct node_t **node);
 
 enum node_type_e { NODE_TYPE_ROOT = 0u, NODE_TYPE_TEXT };
 
-struct position_t {
-  double x;
-  double y;
-};
-
 struct node_t {
   enum node_type_e type;
   struct position_t position;
+  struct rectangle_t margin;
+  struct rectangle_t padding;
   union data {
     bool root;               // NODE_TYPE_ROOT
     struct node_text_t text; // NODE_TYPE_TEXT
@@ -30,6 +28,14 @@ struct node_t {
 struct node_t *render_tree_node_init();
 double render_tree_node_get_x(const struct node_t *node);
 double render_tree_node_get_y(const struct node_t *node);
+double render_tree_node_get_margin_top(const struct node_t *node);
+double render_tree_node_get_margin_left(const struct node_t *node);
+double render_tree_node_get_margin_right(const struct node_t *node);
+double render_tree_node_get_margin_bottom(const struct node_t *node);
+double render_tree_node_get_padding_top(const struct node_t *node);
+double render_tree_node_get_padding_left(const struct node_t *node);
+double render_tree_node_get_padding_right(const struct node_t *node);
+double render_tree_node_get_padding_bottom(const struct node_t *node);
 void render_tree_node_free_data(struct node_t *node);
 void render_tree_node_free(struct node_t **node);
 

--- a/crates/gosub-bindings/include/nodes/text.h
+++ b/crates/gosub-bindings/include/nodes/text.h
@@ -17,9 +17,9 @@ struct node_text_t {
 
 void render_tree_node_text_free_data(struct node_text_t *text);
 
-const char *render_tree_node_text_value(const struct node_t *node);
-const char *render_tree_node_text_font(const struct node_t *node);
-double render_tree_node_text_font_size(const struct node_t *node);
-bool render_tree_node_text_bold(const struct node_t *node);
+const char *render_tree_node_text_get_value(const struct node_t *node);
+const char *render_tree_node_text_get_font(const struct node_t *node);
+double render_tree_node_text_get_font_size(const struct node_t *node);
+bool render_tree_node_text_get_bold(const struct node_t *node);
 
 #endif

--- a/crates/gosub-bindings/include/properties.h
+++ b/crates/gosub-bindings/include/properties.h
@@ -1,0 +1,16 @@
+#ifndef GOSUB_API_PROPERTIES_H
+#define GOSUB_API_PROPERTIES_H
+
+struct position_t {
+  double x;
+  double y;
+};
+
+struct rectangle_t {
+  double top;
+  double left;
+  double right;
+  double bottom;
+};
+
+#endif

--- a/crates/gosub-bindings/src/lib.rs
+++ b/crates/gosub-bindings/src/lib.rs
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn gosub_render_tree_next_node(
 pub unsafe extern "C" fn gosub_render_tree_get_node_data(node: *const Node, c_node: *mut CNode) {
     // Change this to a match when we have more types
     if let NodeType::Text(text_node) = &(*node).node_type {
-        (*c_node) = CNode::new_text(&(*node).position, text_node);
+        *c_node = CNode::new_text(&*node, text_node);
     }
 }
 

--- a/crates/gosub-bindings/src/nodes.c
+++ b/crates/gosub-bindings/src/nodes.c
@@ -29,6 +29,38 @@ double render_tree_node_get_y(const struct node_t *node) {
   return node->position.y;
 }
 
+double render_tree_node_get_margin_top(const struct node_t *node) {
+  return node->margin.top;
+}
+
+double render_tree_node_get_margin_left(const struct node_t *node) {
+  return node->margin.left;
+}
+
+double render_tree_node_get_margin_right(const struct node_t *node) {
+  return node->margin.right;
+}
+
+double render_tree_node_get_margin_bottom(const struct node_t *node) {
+  return node->margin.bottom;
+}
+
+double render_tree_node_get_padding_top(const struct node_t *node) {
+  return node->padding.top;
+}
+
+double render_tree_node_get_padding_left(const struct node_t *node) {
+  return node->padding.left;
+}
+
+double render_tree_node_get_padding_right(const struct node_t *node) {
+  return node->padding.right;
+}
+
+double render_tree_node_get_padding_bottom(const struct node_t *node) {
+  return node->padding.bottom;
+}
+
 void render_tree_node_free(struct node_t **node) {
   free(*node);
   *node = NULL;

--- a/crates/gosub-bindings/src/nodes/text.c
+++ b/crates/gosub-bindings/src/nodes/text.c
@@ -9,28 +9,28 @@ void render_tree_node_text_free_data(struct node_text_t *text) {
   text->font = NULL;
 }
 
-const char *render_tree_node_text_value(const struct node_t *node) {
+const char *render_tree_node_text_get_value(const struct node_t *node) {
   if (!node)
     return NULL;
 
   return (const char *)node->data.text.value;
 }
 
-const char *render_tree_node_text_font(const struct node_t *node) {
+const char *render_tree_node_text_get_font(const struct node_t *node) {
   if (!node)
     return NULL;
 
   return (const char *)node->data.text.font;
 }
 
-double render_tree_node_text_font_size(const struct node_t *node) {
+double render_tree_node_text_get_font_size(const struct node_t *node) {
   if (!node)
     return 0.0;
 
   return node->data.text.font_size;
 }
 
-bool render_tree_node_text_bold(const struct node_t *node) {
+bool render_tree_node_text_get_bold(const struct node_t *node) {
   if (!node)
     return false;
 

--- a/crates/gosub-bindings/src/wrapper/node.rs
+++ b/crates/gosub-bindings/src/wrapper/node.rs
@@ -1,4 +1,5 @@
-use gosub_engine::render_tree::{text::TextNode, Position};
+use gosub_engine::render_tree::properties::{Position, Rectangle};
+use gosub_engine::render_tree::{text::TextNode, Node};
 
 use crate::wrapper::{text::CTextNode, CNodeType};
 
@@ -12,6 +13,8 @@ pub enum CNodeData {
 pub struct CNode {
     pub tag: CNodeType,
     pub position: Position,
+    pub margin: Rectangle,
+    pub padding: Rectangle,
     pub data: CNodeData,
 }
 
@@ -20,6 +23,8 @@ impl Default for CNode {
         Self {
             tag: CNodeType::Root,
             position: Position::new(),
+            margin: Rectangle::new(),
+            padding: Rectangle::new(),
             data: CNodeData::Root(true),
         }
     }
@@ -30,10 +35,12 @@ impl CNode {
         Self::default()
     }
 
-    pub fn new_text(position: &Position, text_node: &TextNode) -> Self {
+    pub fn new_text(node: &Node, text_node: &TextNode) -> Self {
         Self {
             tag: CNodeType::Text,
-            position: (*position).clone(),
+            position: node.position.clone(),
+            margin: node.margin.clone(),
+            padding: node.padding.clone(),
             data: CNodeData::Text(CTextNode::from(text_node)),
         }
     }

--- a/crates/gosub-bindings/tests/render_tree_test.c
+++ b/crates/gosub-bindings/tests/render_tree_test.c
@@ -25,80 +25,90 @@ int main() {
 
   const double tol = 0.00001;
 
-  // TODO: it'll be good at some point in the future to have the
-  // margins to compute the expected_y position instead of manually
-  // doing math. This will make the tests more robust if we change
-  // margins/etc. in the engine.
+  double y = 0.00;
 
   // <h1>
   node = render_tree_next(&render_tree);
+  y += render_tree_node_get_margin_top(node);
   assert(node->type == NODE_TYPE_TEXT);
-  assert(strcmp(node->data.text.value, "this is heading 1") == 0);
-  assert(strcmp(node->data.text.font, "Times New Roman") == 0);
-  assert(fabs(node->data.text.font_size - 37.0) < 0.00001);
-  assert(node->data.text.is_bold == true);
-  assert(fabs(node->position.x - 0.00) < tol);
-  assert(fabs(node->position.y - 10.72) < tol);
+  assert(strcmp(render_tree_node_text_get_value(node), "this is heading 1") == 0);
+  assert(strcmp(render_tree_node_text_get_font(node), "Times New Roman") == 0);
+  assert(fabs(render_tree_node_text_get_font_size(node) - 37.0) < tol);
+  assert(render_tree_node_text_get_bold(node) == true);
+  assert(fabs(render_tree_node_get_x(node) - 0.00) < tol);
+  assert(fabs(render_tree_node_get_y(node) - y) < tol);
+  y += (render_tree_node_text_get_font_size(node) + render_tree_node_get_margin_bottom(node));
 
   // <h2>
   node = render_tree_next(&render_tree);
+  y += render_tree_node_get_margin_top(node);
   assert(node->type == NODE_TYPE_TEXT);
-  assert(strcmp(node->data.text.value, "this is heading 2") == 0);
-  assert(strcmp(node->data.text.font, "Times New Roman") == 0);
-  assert(fabs(node->data.text.font_size - 27.5) < 0.00001);
-  assert(node->data.text.is_bold == true);
-  assert(fabs(node->position.x - 0.00) < tol);
-  assert(fabs(node->position.y - 68.4) < tol);
+  assert(strcmp(render_tree_node_text_get_value(node), "this is heading 2") == 0);
+  assert(strcmp(render_tree_node_text_get_font(node), "Times New Roman") == 0);
+  assert(fabs(render_tree_node_text_get_font_size(node) - 27.5) < tol);
+  assert(render_tree_node_text_get_bold(node) == true);
+  assert(fabs(render_tree_node_get_x(node) - 0.00) < tol);
+  assert(fabs(render_tree_node_get_y(node) - y) < tol);
+  y += (render_tree_node_text_get_font_size(node) + render_tree_node_get_margin_bottom(node));
 
   // <h3>
   node = render_tree_next(&render_tree);
+  y += render_tree_node_get_margin_top(node);
   assert(node->type == NODE_TYPE_TEXT);
-  assert(strcmp(node->data.text.value, "this is heading 3") == 0);
-  assert(strcmp(node->data.text.font, "Times New Roman") == 0);
-  assert(fabs(node->data.text.font_size - 21.5) < 0.00001);
-  assert(node->data.text.is_bold == true);
-  assert(fabs(node->position.x - 0.00) < tol);
-  assert(fabs(node->position.y - 115.22) < tol);
+  assert(strcmp(render_tree_node_text_get_value(node), "this is heading 3") == 0);
+  assert(strcmp(render_tree_node_text_get_font(node), "Times New Roman") == 0);
+  assert(fabs(render_tree_node_text_get_font_size(node) - 21.5) < tol);
+  assert(render_tree_node_text_get_bold(node) == true);
+  assert(fabs(render_tree_node_get_x(node) - 0.00) < tol);
+  assert(fabs(render_tree_node_get_y(node) - y) < tol);
+  y += (render_tree_node_text_get_font_size(node) + render_tree_node_get_margin_bottom(node));
 
   // <h4>
   node = render_tree_next(&render_tree);
+  y += render_tree_node_get_margin_top(node);
   assert(node->type == NODE_TYPE_TEXT);
-  assert(strcmp(node->data.text.value, "this is heading 4") == 0);
-  assert(strcmp(node->data.text.font, "Times New Roman") == 0);
-  assert(fabs(node->data.text.font_size - 18.5) < 0.00001);
-  assert(node->data.text.is_bold == true);
-  assert(fabs(node->position.x - 0.00) < tol);
-  assert(fabs(node->position.y - 156.72) < tol);
+  assert(strcmp(render_tree_node_text_get_value(node), "this is heading 4") == 0);
+  assert(strcmp(render_tree_node_text_get_font(node), "Times New Roman") == 0);
+  assert(fabs(render_tree_node_text_get_font_size(node) - 18.5) < tol);
+  assert(render_tree_node_text_get_bold(node) == true);
+  assert(fabs(render_tree_node_get_x(node) - 0.00) < tol);
+  assert(fabs(render_tree_node_get_y(node) - y) < tol);
+  y += (render_tree_node_text_get_font_size(node) + render_tree_node_get_margin_bottom(node));
 
   // <h5>
   node = render_tree_next(&render_tree);
+  y += render_tree_node_get_margin_top(node);
   assert(node->type == NODE_TYPE_TEXT);
-  assert(strcmp(node->data.text.value, "this is heading 5") == 0);
-  assert(strcmp(node->data.text.font, "Times New Roman") == 0);
-  assert(fabs(node->data.text.font_size - 15.5) < 0.00001);
-  assert(node->data.text.is_bold == true);
-  assert(fabs(node->position.x - 0.00) < tol);
-  assert(fabs(node->position.y - 196.949) < tol);
+  assert(strcmp(render_tree_node_text_get_value(node), "this is heading 5") == 0);
+  assert(strcmp(render_tree_node_text_get_font(node), "Times New Roman") == 0);
+  assert(fabs(render_tree_node_text_get_font_size(node) - 15.5) < tol);
+  assert(render_tree_node_text_get_bold(node) == true);
+  assert(fabs(render_tree_node_get_x(node) - 0.00) < tol);
+  assert(fabs(render_tree_node_get_y(node) - y) < tol);
+  y += (render_tree_node_text_get_font_size(node) + render_tree_node_get_margin_bottom(node));
 
   // <h6>
   node = render_tree_next(&render_tree);
+  y += render_tree_node_get_margin_top(node);
   assert(node->type == NODE_TYPE_TEXT);
-  assert(strcmp(node->data.text.value, "this is heading 6") == 0);
-  assert(strcmp(node->data.text.font, "Times New Roman") == 0);
-  assert(fabs(node->data.text.font_size - 12.0) < 0.00001);
-  assert(node->data.text.is_bold == true);
-  assert(fabs(node->position.x - 0.00) < tol);
-  assert(fabs(node->position.y - 236.027) < tol);
+  assert(strcmp(render_tree_node_text_get_value(node), "this is heading 6") == 0);
+  assert(strcmp(render_tree_node_text_get_font(node), "Times New Roman") == 0);
+  assert(fabs(render_tree_node_text_get_font_size(node) - 12.0) < tol);
+  assert(render_tree_node_text_get_bold(node) == true);
+  assert(fabs(render_tree_node_get_x(node) - 0.00) < tol);
+  assert(fabs(render_tree_node_get_y(node) - y) < tol);
+  y += (render_tree_node_text_get_font_size(node) + render_tree_node_get_margin_bottom(node));
 
   // <p>
   node = render_tree_next(&render_tree);
+  y += render_tree_node_get_margin_top(node);
   assert(node->type == NODE_TYPE_TEXT);
-  assert(strcmp(node->data.text.value, "this is a paragraph") == 0);
-  assert(strcmp(node->data.text.font, "Times New Roman") == 0);
-  assert(fabs(node->data.text.font_size - 18.5) < 0.00001);
-  assert(node->data.text.is_bold == false);
-  assert(fabs(node->position.x - 0.00) < tol);
-  assert(fabs(node->position.y - 268.516) < tol);
+  assert(strcmp(render_tree_node_text_get_value(node), "this is a paragraph") == 0);
+  assert(strcmp(render_tree_node_text_get_font(node), "Times New Roman") == 0);
+  assert(fabs(render_tree_node_text_get_font_size(node) - 18.5) < tol);
+  assert(render_tree_node_text_get_bold(node) == false);
+  assert(fabs(render_tree_node_get_x(node) - 0.00) < tol);
+  assert(fabs(render_tree_node_get_y(node) - y) < tol);
 
   // end of iterator, last node is free'd
   node = render_tree_next(&render_tree);

--- a/src/render_tree.rs
+++ b/src/render_tree.rs
@@ -5,66 +5,12 @@ use crate::html5::node::NodeData;
 use crate::html5::parser::document;
 use crate::html5::parser::document::{Document, DocumentHandle};
 
+use crate::render_tree::properties::Position;
 use crate::render_tree::{properties::Rectangle, text::TextNode};
 
 pub mod properties;
 pub mod text;
 pub mod util;
-
-/// The position of the render cursor used to determine where
-/// to draw an object
-#[derive(Debug, PartialEq, Clone)]
-#[repr(C)]
-pub struct Position {
-    pub x: f64,
-    pub y: f64,
-}
-
-impl Position {
-    #[must_use]
-    pub fn new() -> Self {
-        Self { x: 0., y: 0. }
-    }
-
-    pub fn new_from_existing(position: &Position) -> Self {
-        Self {
-            x: position.x,
-            y: position.y,
-        }
-    }
-
-    /// Move position to (x, y)
-    pub fn move_to(&mut self, x: f64, y: f64) {
-        self.x = x;
-        self.y = y;
-    }
-
-    /// Move position relative to another position.
-    /// x = relative.x + x_offset
-    /// y = relative.y + y_offset
-    pub fn move_relative_to(&mut self, relative_position: &Position, x_offset: f64, y_offset: f64) {
-        self.x = relative_position.x + x_offset;
-        self.y = relative_position.y + y_offset;
-    }
-
-    /// Adjust y by an offset.
-    /// y += offset_y
-    pub fn offset_y(&mut self, offset_y: f64) {
-        self.y += offset_y;
-    }
-
-    /// Adjust x by an offset.
-    /// x += offset_x
-    pub fn offset_x(&mut self, offset_x: f64) {
-        self.x += offset_x;
-    }
-}
-
-impl Default for Position {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 /// A RenderTree is a data structure to be consumed by a user agent
 /// that combines the DOM and CSSOM to compute layouts and styles
@@ -257,7 +203,7 @@ impl Default for Node {
 #[repr(C, u32)]
 pub enum NodeType {
     /// Serves no purpose besides being the entry point
-    // NOTE: the bool is a dummy value, otherwise it appears to be ignored when transfering to C API
+    // NOTE: the bool is a dummy value, otherwise it appears to be ignored when transferring to C API
     Root(bool),
     /// Represents text to render. Usually created from heading or paragraph elements in the DOM.
     Text(TextNode),

--- a/src/render_tree/properties.rs
+++ b/src/render_tree/properties.rs
@@ -1,5 +1,5 @@
 /// Rectangular dimensions commonly used for certain properties such as margin/padding
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[repr(C)]
 pub struct Rectangle {
     pub top: f64,
@@ -32,5 +32,60 @@ impl Rectangle {
             right,
             bottom,
         }
+    }
+}
+
+/// The position of the render cursor used to determine where
+/// to draw an object
+#[derive(Debug, PartialEq, Clone)]
+#[repr(C)]
+pub struct Position {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Position {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { x: 0., y: 0. }
+    }
+
+    pub fn new_from_existing(position: &Position) -> Self {
+        Self {
+            x: position.x,
+            y: position.y,
+        }
+    }
+
+    /// Move position to (x, y)
+    pub fn move_to(&mut self, x: f64, y: f64) {
+        self.x = x;
+        self.y = y;
+    }
+
+    /// Move position relative to another position.
+    /// x = relative.x + x_offset
+    /// y = relative.y + y_offset
+    pub fn move_relative_to(&mut self, relative_position: &Position, x_offset: f64, y_offset: f64) {
+        self.x = relative_position.x + x_offset;
+        self.y = relative_position.y + y_offset;
+    }
+
+    /// Adjust y by an offset.
+    /// y += offset_y
+    pub fn offset_y(&mut self, offset_y: f64) {
+        self.y += offset_y;
+    }
+
+    /// Adjust x by an offset.
+    /// x += offset_x
+    pub fn offset_x(&mut self, offset_x: f64) {
+        self.x += offset_x;
+    }
+}
+
+impl Default for Position {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
This includes margin and padding (for later) into the `node_t` struct and testing the "public" API instead of the struct internals (since that's how they will be used by user agents.) 

There's also some slight reorganization such as moving Position struct into the properties (as well as creating a properties.h header that does something similar to kind of mimic the Rust structure)