### PR TITLE
update section on C API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This is an initial (but not fully complete) contribution guide.
 * [Modules](#modules)
 * [Signed Commits](#signed-commits)
 * [PR Guidelines](#pr-guidelines)
-* [Waht to do?](#what-to-do)
+* [What to do?](#what-to-do)
 
 ## Introduction to the Makefiles
 Before writing any code, it's good to get familiar with our Makefiles.
@@ -39,7 +39,7 @@ In the root directory, run `make format` to have clippy automatically fix some o
 In the root directory, run `make bench` to run the benchmarks.
 
 ### Building C API Bindings
-In the `crates/gosub-bindings` directory, run `make bindings` (may need to `cargo build` first if you didn't use `make build` from the root) to build the C static libraries.
+In the `crates/gosub-bindings` directory, run `make bindings` to build the C static libraries. For more information on this, see the [README](crates/gosub-bindings/README.md).
 
 Can also run `make test` in the same directory to build and run the tests for the C bindings.
 


### PR DESCRIPTION
From a recent PR, users are no longer required to manually `cargo build` anymore. Updating note here