### PR TITLE
Optimize release and benchmark builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,16 @@ test-case = "3.3.1"
 [features]
 # Enables extended debugging information during parsing.
 debug_parser = []
+
+
+[profile.release]
+lto = "fat"
+opt-level = 3
+codegen-units = 1
+#rustflags = ["-C", "target-cpu=native"] # Currently unstable and it can cause problems on older CPUs (don't have newer CPU instructions).
+
+[profile.bench]
+lto = "fat"
+opt-level = 3
+codegen-units = 1
+


### PR DESCRIPTION
I've added some options in `Cargo.toml` to optimize the performance of release and benchmark builds.

- `lto` or link time optimizations, allows optimizations across codegen units and even languages (for example when we are using v8). It also inlines most of the functions. See [this](https://www.reddit.com/r/rust/comments/ijwya5/whats_the_deal_with_lto/) and [this](https://doc.rust-lang.org/cargo/reference/profiles.html#lto)
- `codegen-units` Disallows the compiler to split code in multiple codegen-units, which results in a bit better performence.
- `opt-level` Level at which the compiler optimizes things. (e.g unrolling loops, ...)


This of course causes the build to take much longer. From my measurements a full release build takes about 23.3s instead of 10.8s on my machine. A rebuild (with some dependencies already built) takes 17.3s instead of 2.8s.

Development builds are untouched, so they only take 6.2s with or without these options.

The benchmark results go up ~10-11%. 


<details>

<summary> Benchmark results </summary>

## TreeIterator - wikipedia

![TreeIterator](https://github.com/gosub-browser/gosub-engine/assets/105171995/3db0034c-e828-4354-8edf-c27389d9697e)

## TreeIterator - stackoverflow

![TreeIterator](https://github.com/gosub-browser/gosub-engine/assets/105171995/cc27d923-dc5d-4c39-aaeb-6ae7c0428369)


## TreeConstructor

![TreeConstructor](https://github.com/gosub-browser/gosub-engine/assets/105171995/487f4728-24e2-4d10-9c41-648dc11f3c7c)

## Tokenizer

![Tokenizer](https://github.com/gosub-browser/gosub-engine/assets/105171995/be8f56d3-4f06-48c9-8456-b96fbd7a75b5)



</details>
