### PR TITLE
use chardet to detect encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chardet"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a48563284b67c003ba0fb7243c87fab68885e1532c605704228a80238512e31"
+
+[[package]]
 name = "ciborium"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +679,7 @@ name = "gosub-engine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chardet",
  "clap",
  "cli-table",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ testing_logger = "0.1.1"
 cookie = { version = "0.18.0", features = ["secure", "private"] }
 http = "1.0.0"
 url = "2.5.0"
+chardet = "0.2.4"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -155,7 +155,7 @@ impl CharIterator {
         match encoding.1 {
             p if p >= 0.99 => self.confidence = Confidence::Certain,
             p => self.confidence = Confidence::Tentative(p),
-        }
+        };
     }
 
     /// Returns true when the stream pointer is at the end of the stream


### PR DESCRIPTION
use chardet to detect encoding, and also make Confidence::Tentative contain an f32, which is the probability of the encoding