### PR TITLE
Fix id attribute validation

### DIFF
--- a/src/html5/parser.rs
+++ b/src/html5/parser.rs
@@ -4369,7 +4369,6 @@ mod test {
         let mut chars = CharIterator::new();
         chars.read_from_str(
             "<div id=\"my id\"></div> \
-             <div id=\"123\"></div> \
              <div id=\"\"></div>",
             Some(Encoding::UTF8),
         );
@@ -4378,7 +4377,6 @@ mod test {
         let _ = Html5Parser::parse_document(&mut chars, Document::clone(&document), None);
 
         assert!(document.get().get_node_by_named_id("my id").is_none());
-        assert!(document.get().get_node_by_named_id("123").is_none());
         assert!(document.get().get_node_by_named_id("").is_none());
     }
 

--- a/src/html5/parser/document.rs
+++ b/src/html5/parser/document.rs
@@ -1186,7 +1186,7 @@ mod tests {
         for error in &errors {
             println!("{}", error);
         }
-        assert_eq!(errors.len(), 6);
+        assert_eq!(errors.len(), 5);
         assert_eq!(
             errors[0],
             "document task error: ID 'myid' already exists in DOM",
@@ -1202,17 +1202,12 @@ mod tests {
         );
         assert_eq!(
             errors[4],
-            "document task error: Attribute value '123' did not pass validation",
-        );
-        assert_eq!(
-            errors[5],
             "document task error: Attribute value '' did not pass validation",
         );
 
         // validate that invalid changes did not apply to DOM
         let doc_read = document.get();
         assert!(doc_read.named_id_elements.get("my id").is_none());
-        assert!(doc_read.named_id_elements.get("123").is_none());
         assert!(doc_read.named_id_elements.get("").is_none());
     }
 

--- a/src/html5/util.rs
+++ b/src/html5/util.rs
@@ -1,15 +1,5 @@
-/// according to HTML5 spec: 3.2.3.1
-/// https://www.w3.org/TR/2011/WD-html5-20110405/elements.html#the-id-attribute
+/// according to HTML spec:
+/// https://html.spec.whatwg.org/#global-attributes
 pub(crate) fn is_valid_id_attribute_value(value: &str) -> bool {
-    if value.contains(char::is_whitespace) {
-        return false;
-    }
-
-    if value.is_empty() {
-        return false;
-    }
-
-    // must contain at least one character,
-    // but doesn't specify it should *start* with a character
-    value.contains(char::is_alphabetic)
+    !(value.is_empty() || value.contains(|ref c| char::is_ascii_whitespace(c)))
 }


### PR DESCRIPTION
I noticed a few things about this function to validate the `id` attribute of an element:
- The comment links to the outdated W3C HTML5 spec rather than the WHATWG HTML spec.
- The function requires at least one alphabetic character to be present, when no such requirement actually exists. In particular, the spec states that the value can consist of 'just digits' or 'just punctuation', for example. I'm guessing this stems from a misinterpretation of what is meant by 'character'.
- The spec states that the id may not contain any *ASCII* whitespace, but the validation function uses the `is_whitespace` function, which also detects non-ASCII whitespace characters. This means that certain valid IDs would be incorrectly rejected.