### PR TITLE
Github Author file check

### DIFF
--- a/.github/workflows/check_authors.sh
+++ b/.github/workflows/check_authors.sh
@@ -9,13 +9,16 @@ is_in_authors() {
   fi
 }
 
-# Only check the first 10 committers found in the PR
-COMMITTERS=$(git log $1 --pretty=format:"%an;%ae" | sort | uniq | head -n 10)
+# Get all commits in this PR
+COMMITTERS=$(git log -n $1 --pretty=format:"%an;%ae" | sort | uniq | grep -v noreply.github.com)
 
+# shellcheck disable=SC2066
 for committer in "$COMMITTERS" ; do
+  echo "Validating author: $committer"
+
   # split sentence in two parts seperated by a ;
-  local name=$(echo $committer | cut -d ";" -f 1)
-  local email=$(echo $committer | cut -d ";" -f 2)
+  name=$(echo $committer | cut -d ";" -f 1)
+  email=$(echo $committer | cut -d ";" -f 2)
 
   if is_in_authors "$email" == 0 && is_in_authors "$name" == 0; then
     echo "Author $name <$email> was not found in the AUTHORS file"

--- a/.github/workflows/pr-author-check.yml
+++ b/.github/workflows/pr-author-check.yml
@@ -12,18 +12,19 @@ jobs:
   check-author:
     runs-on: ubuntu-latest
     steps:
+      - name: 'PR commits + 1'
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
       - name: Checkout code
         uses: actions/checkout@v4
-
+        with:
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
       - name: Check if PR author is in AUTHORS file
         id: author_found
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: |
-          git fetch origin ${{ github.base_ref }}
-          git fetch origin ${{ github.head_ref }}
-          sh .github/workflows/check_authors.sh "origin/${{ github.base_ref }}..origin/${{ github.head_ref }}" || exit_status=$?
+          sh .github/workflows/check_authors.sh ${{ env.PR_FETCH_DEPTH }} || exit_status=$?
           echo "found=${exit_status:-0}" >> $GITHUB_OUTPUT
       - name: Find Comment
         uses: peter-evans/find-comment@v2


### PR DESCRIPTION
Fixup of the AUTHOR check. It will work on non-local repositories as well (where gosub-browser is the upstream instead of the origin).   

Any committers with  noreply.github.com will automatically be filtered out.