### PR TITLE
CI: add print CPU info on tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,8 @@ jobs:
       matrix:
         rust_version: [ stable, beta, nightly, 1.73.0, "stable minus 1 release", "stable minus 2 releases" ]
     steps:
+      - name: Print CPU info
+        run: lscpu
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
Print CPU info of the CI runner because one [test](https://github.com/gosub-browser/gosub-engine/actions/runs/7905929253/job/21579625141) has failed, probably because of some (missing) CPU features.
If it ever occurs again, we can check.