### PR TITLE
CI: fix ci not running on all targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.rust_version }}
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --verbose --all --all-features
 
   test:
     runs-on: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.rust_version }}
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --all --no-fail-fast --all-features --all-targets
 
   clippy:
     runs-on: ubuntu-latest
@@ -97,7 +97,7 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.rust_version }}
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all --tests -- -D warnings
 
   fmt:
     runs-on: ubuntu-latest
@@ -120,4 +120,4 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}-stable
       - name: Run fmt
-        run: cargo fmt -- --check
+        run: cargo fmt --check --all

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format:  ## Fix formatting and clippy errors
 test_unit:
 	source test-utils.sh ;\
 	section "Cargo test" ;\
-	cargo test --all --all-features
+	cargo test --verbose --all --no-fail-fast --all-features --all-targets
 
 test_clippy:
 	source test-utils.sh ;\


### PR DESCRIPTION
Since #379 CI doesn't run all tests, only the tree construction and tokenizer ones
For example [here](https://github.com/gosub-browser/gosub-engine/actions/runs/8045061843/job/21969685135?pr=383#step:8:450)

Many tests also don't compile anymore, because the use statements aren't working anymore. I noticed this where I added more tests for V8 (#383)


fixes #390