### PR TITLE
Improve array conversion

### DIFF
--- a/crates/gosub_webexecutor/src/js.rs
+++ b/crates/gosub_webexecutor/src/js.rs
@@ -3,10 +3,10 @@ use std::sync::Mutex;
 use lazy_static::lazy_static;
 use thiserror::Error;
 
+pub use array::*;
 pub use compile::*;
 pub use context::*;
 pub use function::*;
-use gosub_shared::types::Result;
 pub use interop::*;
 pub use object::*;
 pub use runtime::*;
@@ -15,6 +15,7 @@ pub use value_conversion::*;
 
 use crate::js::v8::V8Engine;
 
+mod array;
 mod compile;
 mod context;
 mod function;
@@ -48,31 +49,6 @@ pub enum JSError {
 
 lazy_static! {
     pub static ref RUNTIME: Mutex<V8Engine<'static>> = Mutex::new(V8Engine::new());
-}
-
-pub trait JSArray {
-    type RT: JSRuntime;
-
-    fn get(
-        &self,
-        index: <Self::RT as JSRuntime>::ArrayIndex,
-    ) -> Result<<Self::RT as JSRuntime>::Value>;
-
-    fn set(
-        &self,
-        index: <Self::RT as JSRuntime>::ArrayIndex,
-        value: &<Self::RT as JSRuntime>::Value,
-    ) -> Result<()>;
-
-    fn push(&self, value: <Self::RT as JSRuntime>::Value) -> Result<()>;
-
-    fn pop(&self) -> Result<<Self::RT as JSRuntime>::Value>;
-
-    fn remove<T: Into<<Self::RT as JSRuntime>::ArrayIndex>>(&self, index: T) -> Result<()>;
-
-    fn length(&self) -> Result<<Self::RT as JSRuntime>::ArrayIndex>;
-
-    //TODO: implement other things when needed. Maybe also `Iterator`?
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/gosub_webexecutor/src/js/array.rs
+++ b/crates/gosub_webexecutor/src/js/array.rs
@@ -1,0 +1,41 @@
+use crate::js::{JSRuntime, JSValue};
+use gosub_shared::types::Result;
+
+pub trait JSArray: Iterator {
+    type RT: JSRuntime;
+
+    fn get(
+        &self,
+        index: <Self::RT as JSRuntime>::ArrayIndex,
+    ) -> Result<<Self::RT as JSRuntime>::Value>;
+
+    fn set(
+        &self,
+        index: <Self::RT as JSRuntime>::ArrayIndex,
+        value: &<Self::RT as JSRuntime>::Value,
+    ) -> Result<()>;
+
+    fn push(&self, value: <Self::RT as JSRuntime>::Value) -> Result<()>;
+
+    fn pop(&self) -> Result<<Self::RT as JSRuntime>::Value>;
+
+    fn remove<T: Into<<Self::RT as JSRuntime>::ArrayIndex>>(&self, index: T) -> Result<()>;
+
+    fn len(&self) -> <Self::RT as JSRuntime>::ArrayIndex;
+
+    fn is_empty(&self) -> bool;
+
+    fn new(
+        ctx: <Self::RT as JSRuntime>::Context,
+        cap: <Self::RT as JSRuntime>::ArrayIndex,
+    ) -> Result<Self>
+    where
+        Self: Sized;
+
+    fn new_with_data(
+        ctx: <Self::RT as JSRuntime>::Context,
+        data: &[<Self::RT as JSRuntime>::Value],
+    ) -> Result<Self>
+    where
+        Self: Sized;
+}

--- a/crates/gosub_webexecutor/src/js/v8.rs
+++ b/crates/gosub_webexecutor/src/js/v8.rs
@@ -30,6 +30,20 @@ trait FromContext<'a, T> {
     fn from_ctx(ctx: V8Context<'a>, value: T) -> Self;
 }
 
+trait IntoContext<'a, T> {
+    fn into_ctx(self, ctx: V8Context<'a>) -> T;
+}
+
+//impl into context for everything that implements FromContext
+impl<'a, T, U> IntoContext<'a, U> for T
+where
+    U: FromContext<'a, T>,
+{
+    fn into_ctx(self, ctx: V8Context<'a>) -> U {
+        U::from_ctx(ctx, self)
+    }
+}
+
 //V8 keeps track of the state internally, so this is just a dummy struct for the wrapper
 pub struct V8Engine<'a> {
     _marker: std::marker::PhantomData<&'a ()>,

--- a/crates/gosub_webexecutor/src/js/v8/object.rs
+++ b/crates/gosub_webexecutor/src/js/v8/object.rs
@@ -18,7 +18,7 @@ use crate::js::{
 use crate::Error;
 
 pub struct V8Object<'a> {
-    ctx: V8Context<'a>,
+    pub(crate) ctx: V8Context<'a>,
     pub(crate) value: Local<'a, Object>,
 }
 

--- a/crates/gosub_webexecutor/src/js/value.rs
+++ b/crates/gosub_webexecutor/src/js/value.rs
@@ -1,8 +1,9 @@
 use gosub_shared::types::Result;
 
-use crate::js::{JSArray, JSContext, JSObject, JSRuntime, JSType};
+use crate::js::{JSArray, JSContext, JSObject, JSRuntime, JSType, ValueConversion};
 
-pub trait JSValue
+pub trait JSValue:
+    Sized + From<<Self::RT as JSRuntime>::Object> + From<<Self::RT as JSRuntime>::Array>
 where
     Self: Sized,
 {
@@ -15,6 +16,8 @@ where
     fn as_bool(&self) -> Result<bool>;
 
     fn as_object(&self) -> Result<<Self::RT as JSRuntime>::Object>;
+
+    fn as_array(&self) -> Result<<Self::RT as JSRuntime>::Array>;
 
     fn is_string(&self) -> bool;
 
@@ -34,9 +37,17 @@ where
 
     fn type_of(&self) -> JSType;
 
-    // fn new_object() -> Result<Self::Object>;
-    //
-    // fn new_array<T: ValueConversion<Self>>(value: &[T]) -> Result<Self::Array>;
+    fn new_object(ctx: <Self::RT as JSRuntime>::Context)
+        -> Result<<Self::RT as JSRuntime>::Object>;
+
+    fn new_array<T: ValueConversion<Self, Value = Self>>(
+        ctx: <Self::RT as JSRuntime>::Context,
+        value: &[T],
+    ) -> Result<<Self::RT as JSRuntime>::Array>;
+
+    fn new_empty_array(
+        ctx: <Self::RT as JSRuntime>::Context,
+    ) -> Result<<Self::RT as JSRuntime>::Array>;
 
     fn new_string(ctx: <Self::RT as JSRuntime>::Context, value: &str) -> Result<Self>;
 


### PR DESCRIPTION
This PR improves, how JS Arrays are Handled in rust.

You can now use any Vec or Slice and use `to_js_array(ctx)` on it.

<details>
 <summary>
Next Steps
 </summary>

- [JS Interop Macro](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=48671672)
- [Better Way to modify Rust values from JS Functions](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=54107684)
- [Use V8 Slots for Context](https://github.com/orgs/gosub-browser/projects/1/views/1?pane=issue&itemId=54889142)
- [Reevaluate the need of owned context args](https://github.com/orgs/gosub-browser/projects/1/views/1?pane=issue&itemId=54964048)
</details>