### PR TITLE
Uupdate js value covnersion

### DIFF
--- a/crates/gosub_webexecutor/src/js/array.rs
+++ b/crates/gosub_webexecutor/src/js/array.rs
@@ -6,12 +6,12 @@ pub trait JSArray: Iterator {
 
     fn get(
         &self,
-        index: <Self::RT as JSRuntime>::ArrayIndex,
+        index: usize,
     ) -> Result<<Self::RT as JSRuntime>::Value>;
 
     fn set(
         &self,
-        index: <Self::RT as JSRuntime>::ArrayIndex,
+        index: usize,
         value: &<Self::RT as JSRuntime>::Value,
     ) -> Result<()>;
 
@@ -19,15 +19,15 @@ pub trait JSArray: Iterator {
 
     fn pop(&self) -> Result<<Self::RT as JSRuntime>::Value>;
 
-    fn remove<T: Into<<Self::RT as JSRuntime>::ArrayIndex>>(&self, index: T) -> Result<()>;
+    fn remove(&self, index: usize) -> Result<()>;
 
-    fn len(&self) -> <Self::RT as JSRuntime>::ArrayIndex;
+    fn len(&self) -> usize;
 
     fn is_empty(&self) -> bool;
 
     fn new(
         ctx: <Self::RT as JSRuntime>::Context,
-        cap: <Self::RT as JSRuntime>::ArrayIndex,
+        cap: usize,
     ) -> Result<Self>
     where
         Self: Sized;
@@ -38,4 +38,8 @@ pub trait JSArray: Iterator {
     ) -> Result<Self>
     where
         Self: Sized;
+
+    fn as_value(&self) -> <Self::RT as JSRuntime>::Value;
+    
+    fn as_vec(&self) -> Vec<<Self::RT as JSRuntime>::Value>;
 }

--- a/crates/gosub_webexecutor/src/js/array.rs
+++ b/crates/gosub_webexecutor/src/js/array.rs
@@ -1,19 +1,12 @@
-use crate::js::{JSRuntime, JSValue};
+use crate::js::JSRuntime;
 use gosub_shared::types::Result;
 
 pub trait JSArray: Iterator {
     type RT: JSRuntime;
 
-    fn get(
-        &self,
-        index: usize,
-    ) -> Result<<Self::RT as JSRuntime>::Value>;
+    fn get(&self, index: usize) -> Result<<Self::RT as JSRuntime>::Value>;
 
-    fn set(
-        &self,
-        index: usize,
-        value: &<Self::RT as JSRuntime>::Value,
-    ) -> Result<()>;
+    fn set(&self, index: usize, value: &<Self::RT as JSRuntime>::Value) -> Result<()>;
 
     fn push(&self, value: <Self::RT as JSRuntime>::Value) -> Result<()>;
 
@@ -25,10 +18,7 @@ pub trait JSArray: Iterator {
 
     fn is_empty(&self) -> bool;
 
-    fn new(
-        ctx: <Self::RT as JSRuntime>::Context,
-        cap: usize,
-    ) -> Result<Self>
+    fn new(ctx: <Self::RT as JSRuntime>::Context, cap: usize) -> Result<Self>
     where
         Self: Sized;
 
@@ -40,6 +30,6 @@ pub trait JSArray: Iterator {
         Self: Sized;
 
     fn as_value(&self) -> <Self::RT as JSRuntime>::Value;
-    
+
     fn as_vec(&self) -> Vec<<Self::RT as JSRuntime>::Value>;
 }

--- a/crates/gosub_webexecutor/src/js/compile.rs
+++ b/crates/gosub_webexecutor/src/js/compile.rs
@@ -1,6 +1,6 @@
 use gosub_shared::types::Result;
 
-use crate::js::{JSContext, JSRuntime, JSValue};
+use crate::js::JSRuntime;
 
 //compiled code will be stored with this trait for later execution (e.g HTML parsing not done yet)
 pub trait JSCompiled {

--- a/crates/gosub_webexecutor/src/js/context.rs
+++ b/crates/gosub_webexecutor/src/js/context.rs
@@ -1,6 +1,6 @@
 use gosub_shared::types::Result;
 
-use crate::js::{JSArray, JSCompiled, JSFunction, JSObject, JSRuntime, JSValue};
+use crate::js::JSRuntime;
 
 //main trait for JS context (can be implemented for different JS engines like V8, SpiderMonkey, JSC, etc.)
 pub trait JSContext: Clone {

--- a/crates/gosub_webexecutor/src/js/function.rs
+++ b/crates/gosub_webexecutor/src/js/function.rs
@@ -2,9 +2,7 @@ use core::fmt::Display;
 
 use gosub_shared::types::Result;
 
-use crate::js::{JSContext, JSObject, JSRuntime, JSValue};
-
-struct Function<T: JSFunction>(pub T);
+use crate::js::JSRuntime;
 
 //trait for JS functions (interop between JS and Rust)
 pub trait JSFunction {

--- a/crates/gosub_webexecutor/src/js/object.rs
+++ b/crates/gosub_webexecutor/src/js/object.rs
@@ -2,7 +2,7 @@ use core::fmt::Display;
 
 use gosub_shared::types::Result;
 
-use crate::js::{JSContext, JSFunction, JSFunctionVariadic, JSRuntime, JSValue};
+use crate::js::JSRuntime;
 
 pub trait JSObject {
     type RT: JSRuntime;

--- a/crates/gosub_webexecutor/src/js/runtime.rs
+++ b/crates/gosub_webexecutor/src/js/runtime.rs
@@ -17,7 +17,6 @@ pub trait JSRuntime {
     type Function: JSFunction<RT = Self>;
     type FunctionVariadic: JSFunctionVariadic<RT = Self>;
     type Array: JSArray<RT = Self>;
-    type ArrayIndex;
     type FunctionCallBack: JSFunctionCallBack<RT = Self>;
     type FunctionCallBackVariadic: JSFunctionCallBackVariadic<RT = Self>;
     type Args: Args<RT = Self>;

--- a/crates/gosub_webexecutor/src/js/v8.rs
+++ b/crates/gosub_webexecutor/src/js/v8.rs
@@ -1,6 +1,5 @@
-use std::any::Any;
 use std::cell::RefCell;
-use std::ops::{Deref, DerefMut};
+
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
@@ -13,7 +12,7 @@ use gosub_shared::types::Result;
 pub use object::*;
 pub use value::*;
 
-use crate::js::{IntoJSValue, JSArray, JSContext, JSFunction, JSObject, JSRuntime, JSValue};
+use crate::js::JSRuntime;
 
 mod array;
 mod compile;
@@ -124,14 +123,13 @@ impl<'a> JSRuntime for V8Engine<'a> {
 
 #[cfg(test)]
 mod tests {
-    use anyhow;
 
     use crate::js::v8::V8_INITIALIZED;
     use crate::js::{JSContext, JSRuntime, JSValue};
 
     #[test]
     fn v8_engine_initialization() {
-        let mut engine = crate::js::v8::V8Engine::new();
+        let _engine = crate::js::v8::V8Engine::new();
 
         assert!(V8_INITIALIZED.is_completed());
     }

--- a/crates/gosub_webexecutor/src/js/v8.rs
+++ b/crates/gosub_webexecutor/src/js/v8.rs
@@ -13,7 +13,7 @@ use gosub_shared::types::Result;
 pub use object::*;
 pub use value::*;
 
-use crate::js::{JSArray, JSContext, JSFunction, JSObject, JSRuntime, JSValue, ValueConversion};
+use crate::js::{IntoJSValue, JSArray, JSContext, JSFunction, JSObject, JSRuntime, JSValue};
 
 mod array;
 mod compile;

--- a/crates/gosub_webexecutor/src/js/v8.rs
+++ b/crates/gosub_webexecutor/src/js/v8.rs
@@ -106,7 +106,6 @@ impl<'a> JSRuntime for V8Engine<'a> {
     type Function = V8Function<'a>;
     type FunctionVariadic = V8FunctionVariadic<'a>;
     type Array = V8Array<'a>;
-    type ArrayIndex = u32;
     type FunctionCallBack = V8FunctionCallBack<'a>;
     type FunctionCallBackVariadic = V8FunctionCallBackVariadic<'a>;
     type Args = V8Args<'a>;

--- a/crates/gosub_webexecutor/src/js/v8/array.rs
+++ b/crates/gosub_webexecutor/src/js/v8/array.rs
@@ -38,21 +38,22 @@ impl<'a> Iterator for V8Array<'a> {
 impl<'a> JSArray for V8Array<'a> {
     type RT = V8Engine<'a>;
 
-    fn get(&self, index: u32) -> Result<<Self::RT as JSRuntime>::Value> {
-        let Some(value) = self.value.get_index(self.ctx.borrow_mut().scope(), index) else {
+    fn get(&self, index: usize) -> Result<<Self::RT as JSRuntime>::Value> {
+        let Some(value) = self.value.get_index(self.ctx.borrow_mut().scope(), index as u32) else {
             return Err(Error::JS(JSError::Generic(
                 "failed to get a value from an array".to_owned(),
             ))
             .into());
         };
+        
 
         Ok(V8Value::from_value(self.ctx.clone(), value))
     }
 
-    fn set(&self, index: u32, value: &V8Value) -> Result<()> {
+    fn set(&self, index: usize, value: &V8Value) -> Result<()> {
         match self
             .value
-            .set_index(self.ctx.borrow_mut().scope(), index, value.value)
+            .set_index(self.ctx.borrow_mut().scope(), index as u32, value.value)
         {
             Some(_) => Ok(()),
             None => Err(Error::JS(JSError::Conversion(
@@ -100,10 +101,10 @@ impl<'a> JSArray for V8Array<'a> {
         Ok(V8Value::from_value(self.ctx.clone(), value))
     }
 
-    fn remove<T: Into<u32>>(&self, index: T) -> Result<()> {
+    fn remove(&self, index: usize) -> Result<()> {
         if self
             .value
-            .delete_index(self.ctx.borrow_mut().scope(), index.into())
+            .delete_index(self.ctx.borrow_mut().scope(), index as u32)
             .is_none()
         {
             return Err(Error::JS(JSError::Generic(
@@ -115,15 +116,15 @@ impl<'a> JSArray for V8Array<'a> {
         Ok(())
     }
 
-    fn len(&self) -> u32 {
-        self.value.length()
+    fn len(&self) -> usize {
+        self.value.length() as usize
     }
 
     fn is_empty(&self) -> bool {
         self.value.length() == 0
     }
 
-    fn new(ctx: V8Context<'a>, cap: u32) -> Result<Self> {
+    fn new(ctx: V8Context<'a>, cap: usize) -> Result<Self> {
         let value = Array::new(ctx.borrow_mut().scope(), cap as i32);
 
         Ok(Self {
@@ -143,14 +144,24 @@ impl<'a> JSArray for V8Array<'a> {
             next: 0,
         })
     }
+
+    fn as_value(&self) -> <Self::RT as JSRuntime>::Value {
+        V8Value::from_value(self.ctx.clone(), Local::from(self.value))
+    }
+    
+    fn as_vec(&self) -> Vec<<Self::RT as JSRuntime>::Value> {
+        let mut vec = Vec::with_capacity(self.len());
+        for i in 0..self.len() {
+            vec.push(self.get(i).unwrap());
+        }
+        vec
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::js::v8::{V8Array, V8Engine};
-    use crate::js::{
-        ArrayConversion, JSArray, JSContext, JSObject, JSRuntime, JSValue, ValueConversion,
-    };
+    use crate::js::v8::{V8Array, V8Engine, V8Value};
+    use crate::js::{ArrayConversion, IntoJSValue, IntoRustValue, JSArray, JSContext, JSObject, JSRuntime, JSValue};
 
     #[test]
     fn set() {
@@ -235,8 +246,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(array.pop().unwrap().as_string().unwrap(), "Hello World!");
-        assert_eq!(array.get(0u32).unwrap().as_number().unwrap(), 1234.0);
-        assert!(array.get(1u32).unwrap().is_undefined());
+        assert_eq!(array.get(0).unwrap().as_number().unwrap(), 1234.0);
+        assert!(array.get(1).unwrap().is_undefined());
     }
 
     #[test]
@@ -269,6 +280,21 @@ mod tests {
 
         let array: V8Array = [42, 1337, 1234].to_js_array(context.clone()).unwrap();
 
+        assert_eq!(array.len(), 3);
+        assert_eq!(array.get(0).unwrap().as_number().unwrap(), 42.0);
+        assert_eq!(array.get(1).unwrap().as_number().unwrap(), 1337.0);
+        assert_eq!(array.get(2).unwrap().as_number().unwrap(), 1234.0);
+    }
+
+    #[test]
+    fn rust_to_js_value() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array: V8Value = [42, 1337, 1234].to_js_value(context.clone()).unwrap();
+
+        assert!(array.is_array());
+        let array = array.as_array().unwrap();
         assert_eq!(array.len(), 3);
         assert_eq!(array.get(0).unwrap().as_number().unwrap(), 42.0);
         assert_eq!(array.get(1).unwrap().as_number().unwrap(), 1337.0);
@@ -395,5 +421,24 @@ mod tests {
         assert_eq!(array.get(0).unwrap().as_number().unwrap(), 42.0);
         assert_eq!(array.get(1).unwrap().as_number().unwrap(), 1337.0);
         assert_eq!(array.get(2).unwrap().as_number().unwrap(), 1234.0);
+    }
+    
+    #[test]
+    fn js_vec_to_rust() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array = context
+            .run(
+                r#"
+            [42, 1337, 1234]
+        "#,
+            )
+            .unwrap();
+
+        let vec: Vec<u32>= array.as_array().unwrap()
+            .to_rust_value().unwrap();
+
+        assert_eq!(vec, vec![42, 1337, 1234]);
     }
 }

--- a/crates/gosub_webexecutor/src/js/v8/array.rs
+++ b/crates/gosub_webexecutor/src/js/v8/array.rs
@@ -39,13 +39,15 @@ impl<'a> JSArray for V8Array<'a> {
     type RT = V8Engine<'a>;
 
     fn get(&self, index: usize) -> Result<<Self::RT as JSRuntime>::Value> {
-        let Some(value) = self.value.get_index(self.ctx.borrow_mut().scope(), index as u32) else {
+        let Some(value) = self
+            .value
+            .get_index(self.ctx.borrow_mut().scope(), index as u32)
+        else {
             return Err(Error::JS(JSError::Generic(
                 "failed to get a value from an array".to_owned(),
             ))
             .into());
         };
-        
 
         Ok(V8Value::from_value(self.ctx.clone(), value))
     }
@@ -148,7 +150,7 @@ impl<'a> JSArray for V8Array<'a> {
     fn as_value(&self) -> <Self::RT as JSRuntime>::Value {
         V8Value::from_value(self.ctx.clone(), Local::from(self.value))
     }
-    
+
     fn as_vec(&self) -> Vec<<Self::RT as JSRuntime>::Value> {
         let mut vec = Vec::with_capacity(self.len());
         for i in 0..self.len() {
@@ -161,12 +163,15 @@ impl<'a> JSArray for V8Array<'a> {
 #[cfg(test)]
 mod tests {
     use crate::js::v8::{V8Array, V8Engine, V8Value};
-    use crate::js::{ArrayConversion, IntoJSValue, IntoRustValue, JSArray, JSContext, JSObject, JSRuntime, JSValue};
+    use crate::js::{
+        ArrayConversion, IntoJSValue, IntoRustValue, JSArray, JSContext, JSObject, JSRuntime,
+        JSValue,
+    };
 
     #[test]
     fn set() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array = V8Array::new(context.clone(), 2).unwrap();
         array
@@ -182,7 +187,7 @@ mod tests {
     #[test]
     fn get() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array = V8Array::new(context.clone(), 2).unwrap();
 
@@ -200,7 +205,7 @@ mod tests {
     #[test]
     fn push() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array = V8Array::new(context.clone(), 2).unwrap();
 
@@ -217,7 +222,7 @@ mod tests {
     #[test]
     fn out_of_bounds() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array = V8Array::new(context.clone(), 2).unwrap();
 
@@ -234,7 +239,7 @@ mod tests {
     #[test]
     fn pop() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array = V8Array::new(context.clone(), 2).unwrap();
 
@@ -253,7 +258,7 @@ mod tests {
     #[test]
     fn dynamic_resize() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array = V8Array::new(context.clone(), 2).unwrap();
 
@@ -276,7 +281,7 @@ mod tests {
     #[test]
     fn rust_to_js() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array: V8Array = [42, 1337, 1234].to_js_array(context.clone()).unwrap();
 
@@ -289,7 +294,7 @@ mod tests {
     #[test]
     fn rust_to_js_value() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let array: V8Value = [42, 1337, 1234].to_js_value(context.clone()).unwrap();
 
@@ -410,7 +415,7 @@ mod tests {
     #[test]
     fn rust_vec_to_js() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         #[allow(clippy::useless_vec)]
         let vec = vec![42, 1337, 1234];
@@ -422,7 +427,7 @@ mod tests {
         assert_eq!(array.get(1).unwrap().as_number().unwrap(), 1337.0);
         assert_eq!(array.get(2).unwrap().as_number().unwrap(), 1234.0);
     }
-    
+
     #[test]
     fn js_vec_to_rust() {
         let mut engine = V8Engine::new();
@@ -436,8 +441,7 @@ mod tests {
             )
             .unwrap();
 
-        let vec: Vec<u32>= array.as_array().unwrap()
-            .to_rust_value().unwrap();
+        let vec: Vec<u32> = array.as_array().unwrap().to_rust_value().unwrap();
 
         assert_eq!(vec, vec![42, 1337, 1234]);
     }

--- a/crates/gosub_webexecutor/src/js/v8/context.rs
+++ b/crates/gosub_webexecutor/src/js/v8/context.rs
@@ -44,7 +44,6 @@ impl Copied {
 }
 
 pub(crate) enum HandleScopeType<'a> {
-    WithContext(HandleScope<'a>),
     WithContextRef(&'a mut HandleScope<'a>),
     WithoutContext(HandleScope<'a, ()>),
     CallbackScope(CallbackScope<'a>),
@@ -57,7 +56,6 @@ impl<'a> HandleScopeType<'a> {
 
     pub(crate) fn get(&mut self) -> &mut HandleScope<'a, ()> {
         match self {
-            Self::WithContext(scope) => scope,
             Self::WithoutContext(scope) => scope,
             Self::CallbackScope(scope) => scope,
             Self::WithContextRef(scope) => scope,
@@ -121,9 +119,9 @@ impl<'a> V8Ctx<'a> {
         unsafe { self.context_scope.as_mut() }
     }
 
-    pub(crate) fn handle_scope(&mut self) -> &'a mut HandleScope<'a, ()> {
-        unsafe { self.handle_scope.as_mut() }.get()
-    }
+    // pub(crate) fn handle_scope(&mut self) -> &'a mut HandleScope<'a, ()> {
+    //     unsafe { self.handle_scope.as_mut() }.get()
+    // }
 
     pub(crate) fn context(&mut self) -> &'a mut Local<'a, v8::Context> {
         unsafe { self.ctx.as_mut() }
@@ -217,7 +215,7 @@ pub(crate) fn ctx_from_scope_isolate<'a>(
 }
 
 pub(crate) fn ctx_from_function_callback_info(
-    mut scope: CallbackScope,
+    scope: CallbackScope,
     isolate: NonNull<OwnedIsolate>,
 ) -> std::result::Result<V8Context, (HandleScopeType, Error)> {
     let ctx = scope.get_current_context();

--- a/crates/gosub_webexecutor/src/js/v8/function.rs
+++ b/crates/gosub_webexecutor/src/js/v8/function.rs
@@ -573,8 +573,7 @@ impl<'a> JSFunctionVariadic for V8FunctionVariadic<'a> {
 mod tests {
     use crate::js::v8::{V8Engine, V8Function, V8FunctionVariadic};
     use crate::js::{
-        Args, JSFunction, JSFunctionCallBack, JSFunctionVariadic, JSRuntime, JSValue,
-        ValueConversion,
+        Args, IntoJSValue, JSFunction, JSFunctionCallBack, JSFunctionVariadic, JSRuntime, JSValue,
     };
 
     use super::*;

--- a/crates/gosub_webexecutor/src/js/v8/function.rs
+++ b/crates/gosub_webexecutor/src/js/v8/function.rs
@@ -11,8 +11,7 @@ use gosub_shared::types::Result;
 use crate::js::function::{JSFunctionCallBack, JSFunctionCallBackVariadic};
 use crate::js::v8::{ctx_from_function_callback_info, V8Context, V8Engine, V8Value};
 use crate::js::{
-    Args, JSError, JSFunction, JSFunctionVariadic, JSRuntime, JSValue, VariadicArgs,
-    VariadicArgsInternal,
+    Args, JSError, JSFunction, JSFunctionVariadic, JSRuntime, VariadicArgs, VariadicArgsInternal,
 };
 use crate::Error;
 
@@ -40,21 +39,6 @@ impl<'a> V8FunctionCallBack<'a> {
 pub struct V8Args<'a> {
     next: usize,
     args: Vec<Local<'a, v8::Value>>,
-}
-
-impl V8Args<'_> {
-    fn v8(&self) -> &[Local<v8::Value>] {
-        &self.args
-    }
-}
-
-impl<'a> V8Args<'a> {
-    fn new(args: Vec<V8Value<'a>>, ctx: V8Context<'a>) -> Self {
-        Self {
-            next: 0,
-            args: args.iter().map(|x| x.value).collect(),
-        }
-    }
 }
 
 impl<'a> Iterator for V8Args<'a> {
@@ -303,12 +287,6 @@ pub struct V8VariadicArgsInternal<'a> {
     args: Vec<Local<'a, v8::Value>>,
 }
 
-impl V8VariadicArgsInternal<'_> {
-    fn v8(&self) -> &[Local<v8::Value>] {
-        &self.args
-    }
-}
-
 impl<'a> Iterator for V8VariadicArgsInternal<'a> {
     type Item = Local<'a, v8::Value>;
 
@@ -366,14 +344,12 @@ impl<'a> VariadicArgsInternal for V8VariadicArgsInternal<'a> {
         ctx: <Self::RT as JSRuntime>::Context,
     ) -> <Self::RT as JSRuntime>::VariadicArgs {
         V8VariadicArgs {
-            next: 0,
             args: self.as_vec(ctx),
         }
     }
 }
 
 pub struct V8VariadicArgs<'a> {
-    next: usize,
     args: Vec<V8Value<'a>>,
 }
 
@@ -580,7 +556,7 @@ mod tests {
 
     #[test]
     fn function_test() {
-        let mut ctx = V8Engine::new().new_context().unwrap();
+        let ctx = V8Engine::new().new_context().unwrap();
 
         let mut function = {
             let ctx = ctx.clone();
@@ -610,7 +586,7 @@ mod tests {
 
     #[test]
     fn function_variadic_test() {
-        let mut ctx = V8Engine::new().new_context().unwrap();
+        let ctx = V8Engine::new().new_context().unwrap();
 
         let mut function = {
             let ctx = ctx.clone();

--- a/crates/gosub_webexecutor/src/js/v8/object.rs
+++ b/crates/gosub_webexecutor/src/js/v8/object.rs
@@ -9,12 +9,9 @@ use v8::{
 use gosub_shared::types::Result;
 
 use crate::js::v8::{
-    ctx_from, FromContext, V8Context, V8Ctx, V8Engine, V8Function, V8FunctionCallBack,
-    V8FunctionVariadic, V8Value,
+    ctx_from, FromContext, V8Context, V8Ctx, V8Engine, V8Function, V8FunctionVariadic, V8Value,
 };
-use crate::js::{
-    JSArray, JSError, JSGetterCallback, JSObject, JSRuntime, JSSetterCallback, JSValue,
-};
+use crate::js::{JSError, JSGetterCallback, JSObject, JSRuntime, JSSetterCallback, JSValue};
 use crate::Error;
 
 pub struct V8Object<'a> {
@@ -238,7 +235,7 @@ impl<'a> JSObject for V8Object<'a> {
 
         let config = AccessorConfiguration::new(
             |scope: &mut HandleScope,
-             name: Local<Name>,
+             _name: Local<Name>,
              args: PropertyCallbackArguments,
              mut rv: ReturnValue| {
                 let external = match Local::<External>::try_from(args.data()) {
@@ -292,10 +289,10 @@ impl<'a> JSObject for V8Object<'a> {
         )
         .setter(
             |scope: &mut HandleScope,
-             name: Local<Name>,
+             _name: Local<Name>,
              value: Local<Value>,
              args: PropertyCallbackArguments,
-             rv: ReturnValue| {
+             _rv: ReturnValue| {
                 let external = match Local::<External>::try_from(args.data()) {
                     Ok(external) => external,
                     Err(e) => {
@@ -309,8 +306,6 @@ impl<'a> JSObject for V8Object<'a> {
                 };
 
                 let gs = unsafe { &*(external.value() as *const GetterSetter) };
-
-                let mut ctx = scope.get_current_context();
 
                 let ctx = match ctx_from(scope, gs.ctx.borrow().isolate) {
                     Ok(ctx) => ctx,
@@ -357,7 +352,7 @@ mod tests {
 
     use serde_json::to_string;
 
-    use crate::js::v8::V8FunctionCallBackVariadic;
+    use crate::js::v8::{V8FunctionCallBack, V8FunctionCallBackVariadic};
     use crate::js::{
         IntoJSValue, JSFunction, JSFunctionCallBack, JSFunctionCallBackVariadic,
         JSFunctionVariadic, VariadicArgsInternal,
@@ -368,7 +363,7 @@ mod tests {
     #[test]
     fn test_object() {
         let mut engine = V8Engine::new();
-        let mut ctx = engine.new_context().unwrap();
+        let ctx = engine.new_context().unwrap();
 
         let obj = V8Object::new(ctx.clone()).unwrap();
 
@@ -382,9 +377,9 @@ mod tests {
     #[test]
     fn test_object_accessor() {
         let mut engine = V8Engine::new();
-        let mut ctx = engine.new_context().unwrap();
+        let ctx = engine.new_context().unwrap();
 
-        let mut string = Rc::new(RefCell::new("value".to_string()));
+        let string = Rc::new(RefCell::new("value".to_string()));
 
         let getter = {
             let string = Rc::clone(&string);
@@ -413,11 +408,11 @@ mod tests {
     #[test]
     fn test_object_method() {
         let mut engine = V8Engine::new();
-        let mut ctx = engine.new_context().unwrap();
+        let ctx = engine.new_context().unwrap();
 
         let obj = V8Object::new(ctx.clone()).unwrap();
 
-        let called = Rc::new(RefCell::new(false));
+        let _called = Rc::new(RefCell::new(false));
         let mut func = V8Function::new(ctx.clone(), |cb: &mut V8FunctionCallBack| {
             let value = V8Value::new_string(cb.context().clone(), "value").unwrap();
             cb.ret(value);
@@ -435,11 +430,11 @@ mod tests {
     #[test]
     fn test_object_method_variadic() {
         let mut engine = V8Engine::new();
-        let mut ctx = engine.new_context().unwrap();
+        let ctx = engine.new_context().unwrap();
 
         let obj = V8Object::new(ctx.clone()).unwrap();
 
-        let called = Rc::new(RefCell::new(false));
+        let _called = Rc::new(RefCell::new(false));
         let func = V8FunctionVariadic::new(ctx.clone(), |cb: &mut V8FunctionCallBackVariadic| {
             let ctx = cb.context().clone();
 

--- a/crates/gosub_webexecutor/src/js/v8/object.rs
+++ b/crates/gosub_webexecutor/src/js/v8/object.rs
@@ -359,8 +359,8 @@ mod tests {
 
     use crate::js::v8::V8FunctionCallBackVariadic;
     use crate::js::{
-        JSFunction, JSFunctionCallBack, JSFunctionCallBackVariadic, JSFunctionVariadic,
-        ValueConversion, VariadicArgsInternal,
+        IntoJSValue, JSFunction, JSFunctionCallBack, JSFunctionCallBackVariadic,
+        JSFunctionVariadic, VariadicArgsInternal,
     };
 
     use super::*;

--- a/crates/gosub_webexecutor/src/js/v8/value.rs
+++ b/crates/gosub_webexecutor/src/js/v8/value.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use v8::{Array, Data, Local, Value};
+use v8::{Array, Local, Value};
 
 use gosub_shared::types::Result;
 
@@ -447,7 +447,7 @@ mod tests {
     #[test]
     fn new_string() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let value = V8Value::new_string(context, "Hello World!").unwrap();
         assert!(value.is_string());
@@ -457,7 +457,7 @@ mod tests {
     #[test]
     fn new_number() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let value = V8Value::new_number(context, 1234).unwrap();
         assert!(value.is_number());
@@ -467,7 +467,7 @@ mod tests {
     #[test]
     fn new_bool() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let value = V8Value::new_bool(context, true).unwrap();
         assert!(value.is_bool());
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn new_null() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let value = V8Value::new_null(context).unwrap();
         assert!(value.is_null());
@@ -486,7 +486,7 @@ mod tests {
     #[test]
     fn new_undefined() {
         let mut engine = V8Engine::new();
-        let mut context = engine.new_context().unwrap();
+        let context = engine.new_context().unwrap();
 
         let value = V8Value::new_undefined(context).unwrap();
         assert!(value.is_undefined());

--- a/crates/gosub_webexecutor/src/js/value.rs
+++ b/crates/gosub_webexecutor/src/js/value.rs
@@ -1,6 +1,6 @@
 use gosub_shared::types::Result;
 
-use crate::js::{JSArray, JSContext, JSObject, JSRuntime, JSType, ValueConversion};
+use crate::js::{IntoJSValue, JSArray, JSContext, JSObject, JSRuntime, JSType};
 
 pub trait JSValue:
     Sized + From<<Self::RT as JSRuntime>::Object> + From<<Self::RT as JSRuntime>::Array>
@@ -40,7 +40,7 @@ where
     fn new_object(ctx: <Self::RT as JSRuntime>::Context)
         -> Result<<Self::RT as JSRuntime>::Object>;
 
-    fn new_array<T: ValueConversion<Self, Value = Self>>(
+    fn new_array<T: IntoJSValue<Self, Value = Self>>(
         ctx: <Self::RT as JSRuntime>::Context,
         value: &[T],
     ) -> Result<<Self::RT as JSRuntime>::Array>;

--- a/crates/gosub_webexecutor/src/js/value.rs
+++ b/crates/gosub_webexecutor/src/js/value.rs
@@ -1,6 +1,6 @@
 use gosub_shared::types::Result;
 
-use crate::js::{IntoJSValue, JSArray, JSContext, JSObject, JSRuntime, JSType};
+use crate::js::{IntoJSValue, JSRuntime, JSType};
 
 pub trait JSValue:
     Sized + From<<Self::RT as JSRuntime>::Object> + From<<Self::RT as JSRuntime>::Array>

--- a/crates/gosub_webexecutor/src/js/value_conversion.rs
+++ b/crates/gosub_webexecutor/src/js/value_conversion.rs
@@ -1,6 +1,6 @@
 use gosub_shared::types::Result;
 
-use crate::js::{JSArray, JSContext, JSError, JSRuntime, JSValue};
+use crate::js::{JSArray, JSError, JSRuntime, JSValue};
 
 //trait to easily convert Rust types to JS values (just call .to_js_value() on the type)
 pub trait IntoJSValue<V: JSValue> {
@@ -154,13 +154,12 @@ impl<T: JSValue> IntoRustValue<()> for T {
     }
 }
 
-
-impl<A, T> IntoRustValue<Vec<T>> for A 
-    where
-        A: JSArray,
-        <A::RT as JSRuntime>::Value: IntoRustValue<T>,
+impl<A, T> IntoRustValue<Vec<T>> for A
+where
+    A: JSArray,
+    <A::RT as JSRuntime>::Value: IntoRustValue<T>,
 {
-    fn to_rust_value(&self) -> Result<Vec<T>>{
+    fn to_rust_value(&self) -> Result<Vec<T>> {
         let mut vec: Vec<T> = Vec::with_capacity(self.len());
         for i in 0..self.len() {
             vec.push(self.get(i)?.to_rust_value()?);

--- a/crates/gosub_webexecutor/src/js/value_conversion.rs
+++ b/crates/gosub_webexecutor/src/js/value_conversion.rs
@@ -1,9 +1,9 @@
 use gosub_shared::types::Result;
 
-use crate::js::{JSArray, JSContext, JSRuntime, JSValue};
+use crate::js::{JSArray, JSContext, JSError, JSRuntime, JSValue};
 
 //trait to easily convert Rust types to JS values (just call .to_js_value() on the type)
-pub trait ValueConversion<V: JSValue> {
+pub trait IntoJSValue<V: JSValue> {
     type Value: JSValue;
 
     fn to_js_value(&self, ctx: <V::RT as JSRuntime>::Context) -> Result<Self::Value>;
@@ -11,7 +11,7 @@ pub trait ValueConversion<V: JSValue> {
 
 macro_rules! impl_value_conversion {
     (number, $type:ty) => {
-        impl<V: JSValue> ValueConversion<V> for $type {
+        impl<V: JSValue> IntoJSValue<V> for $type {
             type Value = V;
 
             fn to_js_value(&self, ctx: <V::RT as JSRuntime>::Context) -> Result<Self::Value> {
@@ -20,33 +20,11 @@ macro_rules! impl_value_conversion {
         }
     };
 
-    (string, $type:ty) => {
-        impl_value_conversion!(new_string, $type, deref);
-    };
-
-    (bool, $type:ty) => {
-        impl_value_conversion!(new_bool, $type, deref);
-    };
-
-    (array, $type:ty) => {
-        impl_value_conversion!(new_array, $type, deref);
-    };
-
-    ($func:ident, $type:ty, deref) => {
-        impl<V: JSValue> ValueConversion<V> for $type {
+    ($func:ident, $type:ty) => {
+        impl<V: JSValue> IntoJSValue<V> for $type {
             type Value = V;
             fn to_js_value(&self, ctx: <V::RT as JSRuntime>::Context) -> Result<Self::Value> {
                 Self::Value::$func(ctx, *self)
-            }
-        }
-    };
-
-    ($func:ident, $type:ty) => {
-        impl<C: JSContext> ValueConversion<C> for $type {
-            type Context = C;
-
-            fn to_js_value(&self, ctx: C) -> Result<C::Value> {
-                C::Value::$func(ctx, self)
             }
         }
     };
@@ -57,26 +35,28 @@ impl_value_conversion!(number, i16);
 impl_value_conversion!(number, i32);
 impl_value_conversion!(number, i64);
 impl_value_conversion!(number, isize);
+impl_value_conversion!(number, i128);
 impl_value_conversion!(number, u8);
 impl_value_conversion!(number, u16);
 impl_value_conversion!(number, u32);
 impl_value_conversion!(number, u64);
 impl_value_conversion!(number, usize);
+impl_value_conversion!(number, u128);
 impl_value_conversion!(number, f32);
 impl_value_conversion!(number, f64);
 
-impl_value_conversion!(string, &str);
+impl_value_conversion!(new_string, &str);
 
-impl_value_conversion!(bool, bool);
+impl_value_conversion!(new_bool, bool);
 
-impl<V: JSValue> ValueConversion<V> for String {
+impl<V: JSValue> IntoJSValue<V> for String {
     type Value = V;
     fn to_js_value(&self, ctx: <V::RT as JSRuntime>::Context) -> Result<Self::Value> {
         Self::Value::new_string(ctx, self)
     }
 }
 
-impl<V: JSValue> ValueConversion<V> for () {
+impl<V: JSValue> IntoJSValue<V> for () {
     type Value = V;
     fn to_js_value(&self, ctx: <V::RT as JSRuntime>::Context) -> Result<Self::Value> {
         Self::Value::new_undefined(ctx)
@@ -92,7 +72,7 @@ pub trait ArrayConversion<A: JSArray> {
 impl<A, T> ArrayConversion<A> for [T]
 where
     A: JSArray,
-    T: ValueConversion<<A::RT as JSRuntime>::Value, Value = <A::RT as JSRuntime>::Value>,
+    T: IntoJSValue<<A::RT as JSRuntime>::Value, Value = <A::RT as JSRuntime>::Value>,
 {
     type Array = A;
     fn to_js_array(&self, ctx: <A::RT as JSRuntime>::Context) -> Result<A> {
@@ -102,5 +82,58 @@ where
             .collect::<Result<Vec<_>>>()?;
 
         Self::Array::new_with_data(ctx.clone(), &data)
+    }
+}
+
+
+pub trait IntoRustValue<T> {
+    fn to_rust_value(&self) -> Result<T>
+    where
+        Self: Sized;
+}
+
+macro_rules! impl_rust_conversion {
+    ($func:ident, $type:ty, cast) => {
+        impl<T: JSValue> IntoRustValue<$type> for T {
+            fn to_rust_value(&self) -> Result<$type> {
+                Ok(self.$func()? as $type)
+            }
+        }
+    };
+
+    ($func:ident, $type:ty) => {
+        impl<T: JSValue> IntoRustValue<$type> for T {
+            fn to_rust_value(&self) -> Result<$type> {
+                self.$func()
+            }
+        }
+    };
+}
+
+impl_rust_conversion!(as_number, i8, cast);
+impl_rust_conversion!(as_number, i16, cast);
+impl_rust_conversion!(as_number, i32, cast);
+impl_rust_conversion!(as_number, i64, cast);
+impl_rust_conversion!(as_number, isize, cast);
+impl_rust_conversion!(as_number, i128, cast);
+impl_rust_conversion!(as_number, u8, cast);
+impl_rust_conversion!(as_number, u16, cast);
+impl_rust_conversion!(as_number, u32, cast);
+impl_rust_conversion!(as_number, u64, cast);
+impl_rust_conversion!(as_number, usize, cast);
+impl_rust_conversion!(as_number, u128, cast);
+impl_rust_conversion!(as_number, f32, cast);
+impl_rust_conversion!(as_number, f64, cast);
+
+impl_rust_conversion!(as_string, String);
+impl_rust_conversion!(as_bool, bool);
+
+impl<T: JSValue> IntoRustValue<()> for T {
+    fn to_rust_value(&self) -> Result<()> {
+        if self.is_undefined() || self.is_null() {
+            Ok(())
+        } else {
+            Err(JSError::Conversion("Value is not undefined or null".to_string()).into())
+        }
     }
 }

--- a/crates/gosub_webexecutor/src/lib.rs
+++ b/crates/gosub_webexecutor/src/lib.rs
@@ -5,8 +5,6 @@
 
 use thiserror::Error;
 
-#[allow(unused, unused_imports, unused_variables, dead_code)]
-#[allow(dead_code, unused)]
 pub mod js;
 
 #[cfg(test)]

--- a/crates/gosub_webexecutor/src/test.rs
+++ b/crates/gosub_webexecutor/src/test.rs
@@ -1,7 +1,7 @@
 use crate::js::{
-    Args, JSContext, JSFunction, JSFunctionCallBack, JSFunctionCallBackVariadic,
+    Args, IntoJSValue, JSContext, JSFunction, JSFunctionCallBack, JSFunctionCallBackVariadic,
     JSFunctionVariadic, JSGetterCallback, JSInterop, JSObject, JSRuntime, JSSetterCallback,
-    JSValue, ValueConversion, VariadicArgs, VariadicArgsInternal,
+    JSValue, VariadicArgs, VariadicArgsInternal,
 };
 //use webinterop::{web_fns, web_interop};
 use crate::js::v8::V8Engine;


### PR DESCRIPTION
This PR mainly adds another trait `IntoRustValue`, which can convert `JSValue`s into the correct Rust types. Because of that `ValueConversion` was renamed to `IntoJSValue`

This makes it way easier to convert JSValues to Rust values in the macro I want to write. I decided to make a separate PR for that because it doesn't really fit to the macro things.

Secondly, slices and `Vec`s can be can be converted to a JSArray and back.
JSArray can also be converted to JSValue and `Vec<JSValue>`

Finally, I removed the `#[allow(X)] macros and fixed the warnings generated by that.

<details>
<summary>
Next Steps
</summary>

- [JS Interop Macro](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=48671672)
- [Better Way to modify Rust values from JS Functions](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=54107684)
- [Use V8 Slots for Context](https://github.com/orgs/gosub-browser/projects/1/views/1?pane=issue&itemId=54889142)
- [Reevaluate the need of owned context args](https://github.com/orgs/gosub-browser/projects/1/views/1?pane=issue&itemId=54964048)
</details>

