### PR TITLE
reimplement wasm timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1402,11 +1402,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chardet",
+ "getrandom",
+ "js-sys",
  "lazy_static",
  "rand 0.9.0-alpha.1",
  "thiserror",
  "url",
  "uuid",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -3548,6 +3552,31 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
 
 [[package]]
 name = "wayland-backend"

--- a/crates/gosub_shared/Cargo.toml
+++ b/crates/gosub_shared/Cargo.toml
@@ -13,3 +13,12 @@ anyhow = "1.0.82"
 lazy_static = "1.4.0"
 uuid = { version = "1.8.0", features = ["v4"] }
 rand = "0.9.0-alpha.1"
+
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.69"
+getrandom = { version = "0.2.14", features = ["js"] }
+web-sys = { version = "0.3.69", features = ["Performance", "Window"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.20"


### PR DESCRIPTION
This PR reimplements the timings macros for wasm by using JS APIs.

There is also a new test that can be run in a browser by using `wasm-pack test --firefox --headless`