### PR TITLE
Build a crappy debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,27 +152,6 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
-dependencies = [
- "android-properties",
- "bitflags 2.5.0",
- "cc",
- "cesu8",
- "jni",
- "jni-sys",
- "libc",
- "log",
- "ndk 0.8.0",
- "ndk-context",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror",
-]
-
-[[package]]
-name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
@@ -185,7 +164,7 @@ dependencies = [
  "jni-sys",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -442,31 +421,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
-name = "block2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
-dependencies = [
- "block-sys",
- "objc2 0.4.1",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
 ]
 
 [[package]]
@@ -499,9 +459,9 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -988,6 +948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "d3d12"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
+dependencies = [
+ "bitflags 2.5.0",
+ "libloading 0.8.3",
+ "winapi",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1010,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading 0.8.3",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1166,6 +1146,15 @@ name = "font-types"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b7f6040d337bd44434ab21fc6509154edf2cece88b23758d9d64654c4e7730b"
+
+[[package]]
+name = "font-types"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fd7136aca682873d859ef34494ab1a7d3f57ecd485ed40eb6437ee8c85aa29"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1566,11 +1555,8 @@ dependencies = [
  "smallvec",
  "taffy",
  "url",
- "vello",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu",
- "winit 0.29.15",
 ]
 
 [[package]]
@@ -1617,7 +1603,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "rust-fontconfig",
- "vello",
+ "vello 0.1.0",
 ]
 
 [[package]]
@@ -1654,7 +1640,7 @@ dependencies = [
  "log",
  "slotmap",
  "url",
- "winit 0.30.0",
+ "winit",
 ]
 
 [[package]]
@@ -1681,8 +1667,8 @@ dependencies = [
  "image",
  "raw-window-handle",
  "smallvec",
- "vello",
- "wgpu",
+ "vello 0.2.0",
+ "wgpu 0.20.0",
 ]
 
 [[package]]
@@ -1752,7 +1738,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
  "bitflags 2.5.0",
- "gpu-descriptor-types",
+ "gpu-descriptor-types 0.1.2",
+ "hashbrown",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
+dependencies = [
+ "bitflags 2.5.0",
+ "gpu-descriptor-types 0.2.0",
  "hashbrown",
 ]
 
@@ -1761,6 +1758,15 @@ name = "gpu-descriptor-types"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -1960,17 +1966,6 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2 0.3.0",
- "dispatch",
- "objc2 0.4.1",
 ]
 
 [[package]]
@@ -2251,7 +2246,7 @@ checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2265,6 +2260,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -2356,6 +2357,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
+dependencies = [
+ "bitflags 2.5.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,18 +2429,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk"
-version = "0.8.0"
+name = "naga"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
+ "arrayvec",
+ "bit-set",
  "bitflags 2.5.0",
- "jni-sys",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
  "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "raw-window-handle",
+ "num-traits",
+ "rustc-hash",
+ "spirv",
+ "termcolor",
  "thiserror",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2616,22 +2638,12 @@ checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
-dependencies = [
- "objc-sys",
- "objc2-encode 3.0.0",
-]
-
-[[package]]
-name = "objc2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
- "objc2-encode 4.0.3",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -2641,9 +2653,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.5.0",
- "block2 0.5.1",
+ "block2",
  "libc",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation",
@@ -2657,8 +2669,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.5.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2668,17 +2680,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
 ]
-
-[[package]]
-name = "objc2-encode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc2-encode"
@@ -2693,10 +2699,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.5.0",
- "block2 0.5.1",
+ "block2",
  "dispatch",
  "libc",
- "objc2 0.5.2",
+ "objc2",
 ]
 
 [[package]]
@@ -2706,8 +2712,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.5.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2718,8 +2724,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.5.0",
- "block2 0.5.1",
- "objc2 0.5.2",
+ "block2",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -2820,7 +2826,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -2833,9 +2839,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaf7fec601d640555d9a4cab7343eba1e1c7a5a71c9993ff63b4c26bc5d50c5"
+checksum = "3c28d7294093837856bb80ad191cc46a2fcec8a30b43b7a3b0285325f0a917a9"
 dependencies = [
  "kurbo",
  "smallvec",
@@ -2906,7 +2912,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3263,16 +3269,17 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea23eedb4d938031b6d4343222444608727a6aa68ec355e13588d9947ffe92"
 dependencies = [
- "font-types",
+ "font-types 0.4.3",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
+name = "read-fonts"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "e8b8af39d1f23869711ad4cea5e7835a20daa987f80232f7f2a2374d648ca64d"
 dependencies = [
- "bitflags 1.3.2",
+ "bytemuck",
+ "font-types 0.5.5",
 ]
 
 [[package]]
@@ -3470,19 +3477,6 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550"
-dependencies = [
- "ab_glyph",
- "log",
- "memmap2",
- "smithay-client-toolkit",
- "tiny-skia",
-]
-
-[[package]]
-name = "sctk-adwaita"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de61fa7334ee8ee1f5c3c58dcc414fb9361e7e8f5bff9d45f4d69eeb89a7169"
@@ -3591,7 +3585,17 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff28ee3b66d43060ef9a327e0f18e4c1813f194120156b4d4524fac3ba8ce22"
 dependencies = [
- "read-fonts",
+ "read-fonts 0.15.6",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab45fb68b53576a43d4fc0e9ec8ea64e29a4d2cc7f44506964cb75f288222e9"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.19.3",
 ]
 
 [[package]]
@@ -4225,9 +4229,28 @@ dependencies = [
  "futures-intrusive",
  "peniko",
  "raw-window-handle",
- "skrifa",
- "vello_encoding",
- "wgpu",
+ "skrifa 0.15.5",
+ "vello_encoding 0.1.0",
+ "wgpu 0.19.4",
+]
+
+[[package]]
+name = "vello"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08e6dd8a058d02acc1dff78487a0fa34c79bd9b85c01123d97b9134bfd48b24"
+dependencies = [
+ "bytemuck",
+ "futures-intrusive",
+ "log",
+ "peniko",
+ "raw-window-handle",
+ "skrifa 0.19.3",
+ "static_assertions",
+ "thiserror",
+ "vello_encoding 0.2.0",
+ "vello_shaders",
+ "wgpu 0.20.0",
 ]
 
 [[package]]
@@ -4239,7 +4262,32 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko",
- "skrifa",
+ "skrifa 0.15.5",
+]
+
+[[package]]
+name = "vello_encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77306d1ae01e2ef6a2e5dfd6f81696556ddee3e15f6a7422f360759672a0fd90"
+dependencies = [
+ "bytemuck",
+ "guillotiere",
+ "peniko",
+ "skrifa 0.19.3",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_shaders"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3f31e3763e09febb449533238551bca5203aff4513324c8558b4c0b1c546fb"
+dependencies = [
+ "bytemuck",
+ "naga 0.20.0",
+ "thiserror",
+ "vello_encoding 0.2.0",
 ]
 
 [[package]]
@@ -4482,16 +4530,6 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
@@ -4526,7 +4564,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "js-sys",
  "log",
- "naga",
+ "naga 0.19.2",
  "parking_lot",
  "profiling",
  "raw-window-handle",
@@ -4535,9 +4573,35 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 0.19.3",
+ "wgpu-hal 0.19.3",
+ "wgpu-types 0.19.2",
+]
+
+[[package]]
+name = "wgpu"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ff1bfee408e1028e2e3acbf6d32d98b08a5a059ccbf5f33305534453ba5d3e"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga 0.20.0",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 0.20.0",
+ "wgpu-hal 0.20.0",
+ "wgpu-types 0.20.0",
 ]
 
 [[package]]
@@ -4553,7 +4617,7 @@ dependencies = [
  "codespan-reporting",
  "indexmap",
  "log",
- "naga",
+ "naga 0.19.2",
  "once_cell",
  "parking_lot",
  "profiling",
@@ -4562,8 +4626,35 @@ dependencies = [
  "smallvec",
  "thiserror",
  "web-sys",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-hal 0.19.3",
+ "wgpu-types 0.19.2",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6a86eaa5e763e59c73cf9e97d55fffd4dfda69fd8bda19589fcf851ddfef1f"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.5.0",
+ "cfg_aliases 0.1.1",
+ "codespan-reporting",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga 0.20.0",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "web-sys",
+ "wgpu-hal 0.20.0",
+ "wgpu-types 0.20.0",
 ]
 
 [[package]]
@@ -4580,20 +4671,20 @@ dependencies = [
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
- "d3d12",
+ "d3d12 0.19.0",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
- "gpu-descriptor",
+ "gpu-descriptor 0.2.4",
  "hassle-rs",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading 0.8.3",
  "log",
- "metal",
- "naga",
+ "metal 0.27.0",
+ "naga 0.19.2",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
@@ -4607,7 +4698,52 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
+ "wgpu-types 0.19.2",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d71c8ae05170583049b65ee562fd839fdc0b3e9ddb84f4e40c9d5f8ea0d4c8c"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.5.0",
+ "block",
+ "cfg_aliases 0.1.1",
+ "core-graphics-types",
+ "d3d12 0.20.0",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor 0.3.0",
+ "hassle-rs",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.3",
+ "log",
+ "metal 0.28.0",
+ "naga 0.20.0",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types 0.20.0",
  "winapi",
 ]
 
@@ -4616,6 +4752,17 @@ name = "wgpu-types"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+dependencies = [
+ "bitflags 2.5.0",
+ "js-sys",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
  "bitflags 2.5.0",
  "js-sys",
@@ -4897,60 +5044,12 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winit"
-version = "0.29.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
-dependencies = [
- "ahash",
- "android-activity 0.5.2",
- "atomic-waker",
- "bitflags 2.5.0",
- "bytemuck",
- "calloop",
- "cfg_aliases 0.1.1",
- "core-foundation",
- "core-graphics",
- "cursor-icon",
- "icrate",
- "js-sys",
- "libc",
- "log",
- "memmap2",
- "ndk 0.8.0",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc2 0.4.1",
- "once_cell",
- "orbclient",
- "percent-encoding",
- "raw-window-handle",
- "redox_syscall 0.3.5",
- "rustix",
- "sctk-adwaita 0.8.1",
- "smithay-client-toolkit",
- "smol_str",
- "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-plasma",
- "web-sys",
- "web-time 0.2.4",
- "windows-sys 0.48.0",
- "x11-dl",
- "x11rb",
- "xkbcommon-dl",
-]
-
-[[package]]
-name = "winit"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9e6d5d66cbf702e0dd820302144f51b69a95acdc495dd98ca280ff206562b1"
 dependencies = [
  "ahash",
- "android-activity 0.6.0",
+ "android-activity",
  "atomic-waker",
  "bitflags 2.5.0",
  "bytemuck",
@@ -4964,17 +5063,17 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk 0.9.0",
- "objc2 0.5.2",
+ "ndk",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "orbclient",
  "percent-encoding",
  "pin-project",
  "raw-window-handle",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "rustix",
- "sctk-adwaita 0.9.0",
+ "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
  "tracing",
@@ -4986,7 +5085,7 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time 1.1.0",
+ "web-time",
  "windows-sys 0.52.0",
  "x11-dl",
  "x11rb",

--- a/crates/gosub_css3/src/tokenizer.rs
+++ b/crates/gosub_css3/src/tokenizer.rs
@@ -3,7 +3,6 @@ use crate::unicode::{get_unicode_char, UnicodeChar};
 use gosub_shared::byte_stream::Character::Ch;
 use gosub_shared::byte_stream::{ByteStream, Character, Stream};
 use std::fmt;
-use std::usize;
 
 pub type Number = f32;
 

--- a/crates/gosub_render_backend/src/svg.rs
+++ b/crates/gosub_render_backend/src/svg.rs
@@ -1,0 +1,7 @@
+use crate::RenderBackend;
+
+
+
+
+pub trait SvgRenderer<B: RenderBackend> {
+}

--- a/crates/gosub_render_utils/src/position.rs
+++ b/crates/gosub_render_utils/src/position.rs
@@ -3,7 +3,8 @@ use std::cmp::Ordering;
 use rstar::{RTree, RTreeObject, AABB};
 use taffy::{NodeId, PrintTree, TaffyTree};
 
-struct Element {
+#[derive(Debug)]
+pub struct Element {
     id: NodeId,
     x: f32,
     y: f32,
@@ -139,6 +140,14 @@ impl PositionTree {
             })
             .reduce(|a, b| if a.z_index >= b.z_index { a } else { b }) // >= because we just hope that the last-drawn element is last in the list
             .map(|e| e.id)
+    }
+
+    pub fn get_node(&self, id: NodeId) -> Option<&Element> {
+        self.tree.iter().find(|e| e.id == id)
+    }
+
+    pub fn position(&self, id: NodeId) -> Option<(f32, f32)> {
+        self.get_node(id).map(|e| (e.x, e.y))
     }
 }
 

--- a/crates/gosub_renderer/Cargo.toml
+++ b/crates/gosub_renderer/Cargo.toml
@@ -15,10 +15,7 @@ gosub_styling = { path = "../gosub_styling" }
 gosub_net = { path = "../gosub_net" }
 gosub_render_backend = { path = "../gosub_render_backend" }
 taffy = "0.5.1"
-vello = "0.1.0"
-winit = "0.29.15"
 anyhow = "1.0.86"
-wgpu = "0.19.3"
 futures = "0.3.30"
 slotmap = "1.0.7"
 smallvec = "1.13.2"

--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -24,10 +24,20 @@ pub struct TreeDrawer<B: RenderBackend> {
     pub(crate) url: Url,
     pub(crate) position: PositionTree,
     pub(crate) last_hover: Option<NodeId>,
+    pub(crate) debug: bool,
+    pub(crate) debugger_changed: bool,
+    pub(crate) debugger_scene: Option<B::Scene>,
+    pub(crate) tree_scene: Option<B::Scene>,
 }
 
 impl<B: RenderBackend> TreeDrawer<B> {
-    pub fn new(style: StyleTree<B>, taffy: TaffyTree<GosubID>, root: TaffyID, url: Url) -> Self {
+    pub fn new(
+        style: StyleTree<B>,
+        taffy: TaffyTree<GosubID>,
+        root: TaffyID,
+        url: Url,
+        debug: bool,
+    ) -> Self {
         let position = PositionTree::from_taffy(&taffy, root);
         Self {
             style,
@@ -37,6 +47,10 @@ impl<B: RenderBackend> TreeDrawer<B> {
             url,
             position,
             last_hover: None,
+            debug,
+            debugger_scene: None,
+            debugger_changed: false,
+            tree_scene: None,
         }
     }
 }

--- a/crates/gosub_useragent/src/event_loop.rs
+++ b/crates/gosub_useragent/src/event_loop.rs
@@ -54,8 +54,12 @@ impl<D: SceneDrawer<B>, B: RenderBackend> Window<'_, D, B> {
                     return Ok(());
                 };
 
-                tab.data
-                    .mouse_move(backend, &mut self.renderer_data, position.x, position.y);
+                if tab
+                    .data
+                    .mouse_move(backend, &mut self.renderer_data, position.x, position.y)
+                {
+                    self.window.request_redraw();
+                }
             }
 
             _ => {}

--- a/crates/gosub_useragent/src/tabs.rs
+++ b/crates/gosub_useragent/src/tabs.rs
@@ -39,8 +39,8 @@ impl<D: SceneDrawer<B>, B: RenderBackend> Tabs<D, B> {
         self.tabs.get_mut(self.active.0)
     }
 
-    pub(crate) fn from_url(url: Url) -> Result<Self> {
-        let tab = Tab::from_url(url)?;
+    pub(crate) fn from_url(url: Url, debug: bool) -> Result<Self> {
+        let tab = Tab::from_url(url, debug)?;
 
         Ok(Self::new(tab))
     }
@@ -63,8 +63,8 @@ impl<D: SceneDrawer<B>, B: RenderBackend> Tab<D, B> {
         }
     }
 
-    pub fn from_url(url: Url) -> Result<Self> {
-        let data = D::from_url(url.clone())?;
+    pub fn from_url(url: Url, debug: bool) -> Result<Self> {
+        let data = D::from_url(url.clone(), debug)?;
 
         Ok(Self {
             title: url.as_str().to_string(),

--- a/crates/gosub_useragent/src/window.rs
+++ b/crates/gosub_useragent/src/window.rs
@@ -27,7 +27,12 @@ pub struct Window<'a, D: SceneDrawer<B>, B: RenderBackend> {
 }
 
 impl<'a, D: SceneDrawer<B>, B: RenderBackend> Window<'a, D, B> {
-    pub fn new(event_loop: &ActiveEventLoop, backend: &mut B, default_url: Url) -> Result<Self> {
+    pub fn new(
+        event_loop: &ActiveEventLoop,
+        backend: &mut B,
+        default_url: Url,
+        debug: bool,
+    ) -> Result<Self> {
         let window = create_window(event_loop)?;
 
         let renderer_data = backend.create_window_data(window.clone())?;
@@ -36,7 +41,7 @@ impl<'a, D: SceneDrawer<B>, B: RenderBackend> Window<'a, D, B> {
             state: WindowState::Suspended,
             window,
             renderer_data,
-            tabs: Tabs::from_url(default_url)?,
+            tabs: Tabs::from_url(default_url, debug)?,
         })
     }
 

--- a/crates/gosub_v8/src/v8/context.rs
+++ b/crates/gosub_v8/src/v8/context.rs
@@ -264,7 +264,7 @@ pub fn ctx_from<'a>(
     let ctx = scope.get_current_context();
 
     //SAFETY: This can only shorten the lifetime of the scope, which is fine. (we borrow it for 'a and it is '2, which will always be longer than 'a)
-    let scope = unsafe { std::mem::transmute(scope) };
+    let scope = unsafe { std::mem::transmute::<&mut HandleScope<'_>, &mut HandleScope<'_>>(scope) };
 
     let scope = HandleScopeType::WithContextRef(scope);
 

--- a/crates/gosub_vello/Cargo.toml
+++ b/crates/gosub_vello/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 gosub_shared = { path = "../gosub_shared" }
 gosub_render_backend = { path = "../gosub_render_backend" }
 gosub_typeface = { path = "../gosub_typeface" }
-vello = "0.1.0"
+vello = "0.2.0"
 image = "0.25.1"
 smallvec = "1.13.2"
 anyhow = "1.0.82"
-wgpu = "0.19.4"
+wgpu = "0.20.0"
 raw-window-handle = "0.6.2"
 futures = "0.3.30"

--- a/crates/gosub_vello/src/color.rs
+++ b/crates/gosub_vello/src/color.rs
@@ -20,6 +20,22 @@ impl TColor for Color {
         VelloColor::rgba8(r, g, b, a).into()
     }
 
+    fn r(&self) -> u8 {
+        self.0.r
+    }
+
+    fn g(&self) -> u8 {
+        self.0.g
+    }
+
+    fn b(&self) -> u8 {
+        self.0.b
+    }
+
+    fn a(&self) -> u8 {
+        self.0.a
+    }
+
     const WHITE: Self = Color(VelloColor::WHITE);
     const BLACK: Self = Color(VelloColor::BLACK);
     const RED: Self = Color(VelloColor::RED);

--- a/crates/gosub_vello/src/render.rs
+++ b/crates/gosub_vello/src/render.rs
@@ -34,7 +34,7 @@ pub const RENDERER_CONF: VelloRendererOptions = VelloRendererOptions {
         msaa8: true,
         msaa16: true,
     },
-    num_init_threads: NonZeroUsize::new(4),
+    num_init_threads: NonZeroUsize::new(1),
 };
 
 pub struct Renderer {
@@ -147,6 +147,16 @@ impl Renderer {
 
             chosen_adapter
         });
+
+        {
+            let instance = Instance::new(Default::default());
+
+            let adapters = instance.enumerate_adapters(Backends::all());
+
+            for adapter in adapters {
+                println!("Adapter: {:?}", adapter.get_info());
+            }
+        }
 
         #[cfg(target_arch = "wasm32")]
         let mut adapter = None;

--- a/crates/gosub_vello/src/render/window.rs
+++ b/crates/gosub_vello/src/render/window.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use vello::{Renderer, Scene};
+use vello::Renderer;
+
+use crate::Scene;
 
 use super::{InstanceAdapter, SurfaceWrapper};
 

--- a/crates/gosub_vello/src/scene.rs
+++ b/crates/gosub_vello/src/scene.rs
@@ -1,0 +1,63 @@
+use gosub_render_backend::{RenderBackend, RenderRect, RenderText, Scene as TScene};
+use vello::kurbo::RoundedRect;
+use vello::peniko::Fill;
+use vello::Scene as VelloScene;
+
+use crate::{Border, BorderRenderOptions, Text, Transform, VelloBackend};
+
+pub struct Scene(pub(crate) VelloScene);
+
+impl TScene<VelloBackend> for Scene {
+    fn reset(&mut self) {
+        self.0.reset()
+    }
+
+    fn draw_rect(&mut self, rect: &RenderRect<VelloBackend>) {
+        let affine = rect.transform.as_ref().map(|t| t.0).unwrap_or_default();
+
+        let brush = &rect.brush.0;
+        let brush_transform = rect.brush_transform.as_ref().map(|t| t.0);
+
+        if let Some(radius) = &rect.radius {
+            let shape = RoundedRect::from_rect(rect.rect.0, radius.clone());
+            self.0
+                .fill(Fill::NonZero, affine, brush, brush_transform, &shape)
+        } else {
+            self.0
+                .fill(Fill::NonZero, affine, brush, brush_transform, &rect.rect.0)
+        }
+
+        if let Some(border) = &rect.border {
+            let opts = BorderRenderOptions {
+                border,
+                rect: &rect.rect,
+                transform: rect.transform.as_ref(),
+                radius: rect.radius.as_ref(),
+            };
+
+            Border::draw(&mut self.0, opts);
+        }
+    }
+
+    fn draw_text(&mut self, text: &RenderText<VelloBackend>) {
+        Text::show(&mut self.0, text)
+    }
+
+    fn apply_scene(
+        &mut self,
+        scene: &<VelloBackend as RenderBackend>::Scene,
+        transform: Option<Transform>,
+    ) {
+        self.0.append(&scene.0, transform.map(|t| t.0));
+    }
+
+    fn new(_data: &mut <VelloBackend as RenderBackend>::WindowData<'_>) -> Self {
+        VelloScene::new().into()
+    }
+}
+
+impl From<VelloScene> for Scene {
+    fn from(scene: VelloScene) -> Self {
+        Self(scene)
+    }
+}

--- a/src/bin/renderer.rs
+++ b/src/bin/renderer.rs
@@ -1,3 +1,4 @@
+use clap::ArgAction;
 use url::Url;
 
 use gosub_renderer::render_tree::TreeDrawer;
@@ -13,14 +14,21 @@ fn main() -> Result<()> {
                 .required(true)
                 .index(1),
         )
+        .arg(
+            clap::Arg::new("debug")
+                .short('d')
+                .long("debug")
+                .action(ArgAction::SetTrue),
+        )
         .get_matches();
 
     let url: String = matches.get_one::<String>("url").expect("url").to_string();
+    let debug = matches.get_one::<bool>("debug").copied().unwrap_or(false);
 
     // let mut rt = load_html_rendertree(&url)?;
 
     let mut application: Application<TreeDrawer<VelloBackend>, VelloBackend> =
-        Application::new(VelloBackend::new());
+        Application::new(VelloBackend::new(), debug);
 
     application.initial_tab(Url::parse(&url)?);
 

--- a/src/wasm/renderer.rs
+++ b/src/wasm/renderer.rs
@@ -78,7 +78,7 @@ async fn renderer_internal(opts: RendererOptions) -> Result<()> {
 
     let (taffy_tree, root) = generate_taffy_tree(&mut rt)?;
 
-    let render_tree = TreeDrawer::new(rt, taffy_tree, root);
+    let render_tree = TreeDrawer::new(rt, taffy_tree, root, opts.debug);
 
     let render_tree = render_tree;
 


### PR DESCRIPTION
This PR adds a simple debugger that can be enabled with `--debug` or `-d` in the renderer binary.

I noticed an issue with the rendering of borders and vello, it seems like they are clipping into the "main" rect, that has the border.

![image](https://github.com/gosub-browser/gosub-engine/assets/105171995/243fcb9a-57f4-4c51-ab79-ede08f27c3c8)
![image](https://github.com/gosub-browser/gosub-engine/assets/105171995/0f6bc082-1349-4588-9741-b0fd5c9d7e00)
(Note for the image below, i don't had the gosub logo in my work folder, so it is missing, but it still can be inspected by the debugger)

We could add some lines for alignment and information about what you are actually inspecting, but thats something for later.


It's really nice to see finally "interactivity" and not only static pages rendering with gosub! 😀
