### PR TITLE
fix ~600MB Github CI log files

### DIFF
--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -1,7 +1,7 @@
 use core::cell::RefCell;
 use core::option::Option::Some;
 use std::collections::HashMap;
-#[cfg(feature = "debug_parser")]
+#[cfg(all(feature = "debug_parser", test))]
 use std::io::Write;
 use std::rc::Rc;
 
@@ -454,7 +454,7 @@ impl<'chars> Html5Parser<'chars> {
                 }
             }
 
-            #[cfg(feature = "debug_parser")]
+            #[cfg(all(feature = "debug_parser", test))]
             self.display_debug_info();
         }
 
@@ -2724,7 +2724,7 @@ impl<'chars> Html5Parser<'chars> {
             {
                 self.adoption_agency_algorithm(&self.current_token.clone());
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 self.display_debug_info();
             }
             Token::StartTag { name, .. }
@@ -3799,7 +3799,7 @@ impl<'chars> Html5Parser<'chars> {
         self.insertion_mode = InsertionMode::Text;
     }
 
-    #[cfg(feature = "debug_parser")]
+    #[cfg(all(feature = "debug_parser", test))]
     fn display_debug_info(&self) {
         println!("-----------------------------------------\n");
         println!("current token   : '{}'", self.current_token);

--- a/src/bin/parser-test.rs
+++ b/src/bin/parser-test.rs
@@ -62,7 +62,7 @@ fn main() {
 }
 
 fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
-    #[cfg(feature = "debug_parser_verbose")]
+    #[cfg(all(feature = "debug_parser_verbose", test))]
     println!(
         "🧪 Running test #{test_idx}: {}:{}",
         test.file_path, test.line
@@ -75,7 +75,7 @@ fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
         .run_test(test.clone(), false)
         .expect("problem parsing");
 
-    // #[cfg(feature = "debug_parser")]
+    // #[cfg(all(feature = "debug_parser", not(test)))]
     // print_test_result(&result);
 
     for entry in &result.tree_results {
@@ -85,25 +85,25 @@ fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
             ResultStatus::Success => {
                 all_results.succeeded += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!("✅  {}", entry.actual);
             }
             ResultStatus::Missing => {
                 all_results.failed += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!("❌ {} (missing)", entry.expected);
             }
             ResultStatus::Additional => {
                 all_results.failed += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!("❌ {} (unexpected)", entry.actual);
             }
             ResultStatus::Mismatch => {
                 all_results.failed += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!("❌ {} (wanted: {})", entry.actual, entry.expected);
             }
             ResultStatus::IncorrectPosition => {}
@@ -117,7 +117,7 @@ fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
             ResultStatus::Success => {
                 all_results.succeeded += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!(
                     "✅  ({}:{}) {}",
                     entry.actual.line, entry.actual.col, entry.actual.message
@@ -126,7 +126,7 @@ fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
             ResultStatus::Missing => {
                 all_results.failed += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!(
                     "❌ ({}:{}) {} (missing)",
                     entry.expected.line, entry.expected.col, entry.expected.message
@@ -135,7 +135,7 @@ fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
             ResultStatus::Additional => {
                 all_results.failed += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!(
                     "❌ ({}:{}) {} (unexpected)",
                     entry.actual.line, entry.actual.col, entry.actual.message
@@ -144,7 +144,7 @@ fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
             ResultStatus::Mismatch => {
                 all_results.failed += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!(
                     "❌ ({}:{}) {} (wanted: {})",
                     entry.actual.line,
@@ -157,7 +157,7 @@ fn run_test(test_idx: usize, test: Test, all_results: &mut TotalTestResults) {
                 all_results.failed += 1;
                 all_results.failed_position += 1;
 
-                #[cfg(feature = "debug_parser")]
+                #[cfg(all(feature = "debug_parser", test))]
                 println!(
                     "❌ ({}:{}) (wanted: ({}::{})) {}",
                     entry.actual.line,


### PR DESCRIPTION
Since #532 the test logs explode, they get ~600MiB large. You can't even view the in in the github log viewer, the raw log viewer kills your browser and you can't download the logs vie the "Download log Archive" button.


The problem is simple, we're running tests with `--all-features` and `--all-targets`.
This causes the `debug_parser` feature to be enabled, since it was reintroduced in #532 because of the upgrade to rust 1.80. I for now just threw in a additional `test`, so it won't be activated when we are in a testing env, might cause some errors though, but for now it is probably okay.


I guess, for the long term we need a better solution, this is just a quick fix.