### PR TITLE
Debug tree, select specific elements

### DIFF
--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -26,6 +26,7 @@ pub struct TreeDrawer<B: RenderBackend, L: Layouter> {
     pub(crate) dirty: bool,
     pub(crate) debugger_scene: Option<B::Scene>,
     pub(crate) tree_scene: Option<B::Scene>,
+    pub(crate) selected_element: Option<NodeId>,
     pub(crate) scene_transform: Option<B::Transform>,
 }
 
@@ -42,6 +43,7 @@ impl<B: RenderBackend, L: Layouter> TreeDrawer<B, L> {
             debugger_scene: None,
             dirty: false,
             tree_scene: None,
+            selected_element: None,
             scene_transform: None,
         }
     }

--- a/crates/gosub_styling/src/render_tree.rs
+++ b/crates/gosub_styling/src/render_tree.rs
@@ -1,3 +1,5 @@
+mod desc;
+
 use std::collections::HashMap;
 use std::fmt::Debug;
 

--- a/crates/gosub_styling/src/render_tree/desc.rs
+++ b/crates/gosub_styling/src/render_tree/desc.rs
@@ -1,0 +1,55 @@
+use crate::render_tree::{RenderNodeData, RenderTree};
+use gosub_html5::node::NodeId;
+use gosub_render_backend::layout::Layouter;
+use gosub_render_backend::{NodeDesc, PreRenderText, RenderBackend};
+impl<B: RenderBackend, L: Layouter> RenderTree<B, L> {
+    pub fn desc(&self) -> NodeDesc {
+        self.desc_node(self.root)
+    }
+
+    fn desc_node(&self, node: NodeId) -> NodeDesc {
+        let Some(node) = self.get_node(node) else {
+            return NodeDesc {
+                id: 0,
+                name: "<unknown>".into(),
+                children: vec![],
+                attributes: vec![],
+                properties: vec![],
+                text: None,
+            };
+        };
+
+        let attributes = if let RenderNodeData::Element(e) = &node.data {
+            e.attributes
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        } else {
+            vec![]
+        };
+
+        let (name, text) = if let RenderNodeData::Text(t) = &node.data {
+            ("#text".into(), Some(t.prerender.value().into()))
+        } else {
+            (node.name.clone(), None)
+        };
+
+        NodeDesc {
+            id: node.id.into(),
+            name,
+            children: node
+                .children
+                .iter()
+                .map(|child| self.desc_node(*child))
+                .collect(),
+            attributes,
+            properties: node
+                .properties
+                .properties
+                .iter()
+                .map(|(k, v)| (k.clone(), v.actual.to_string()))
+                .collect(),
+            text,
+        }
+    }
+}

--- a/crates/gosub_useragent/src/application.rs
+++ b/crates/gosub_useragent/src/application.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-
 use anyhow::anyhow;
+use std::collections::HashMap;
+use std::sync::mpsc;
 use url::Url;
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
@@ -8,7 +8,7 @@ use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 use winit::window::WindowId;
 
 use gosub_render_backend::layout::{LayoutTree, Layouter};
-use gosub_render_backend::RenderBackend;
+use gosub_render_backend::{NodeDesc, RenderBackend};
 use gosub_renderer::draw::SceneDrawer;
 use gosub_shared::types::Result;
 
@@ -26,6 +26,7 @@ pub struct Application<
     backend: B,
     layouter: L,
     proxy: Option<EventLoopProxy<CustomEvent>>,
+    event_loop: Option<EventLoop<CustomEvent>>,
     debug: bool,
 }
 
@@ -90,6 +91,24 @@ impl<'a, D: SceneDrawer<B, L, LT>, B: RenderBackend, L: Layouter, LT: LayoutTree
                     self.windows.insert(window.id(), window);
                 }
             }
+            CustomEvent::Select(id) => {
+                if let Some(window) = self.windows.values_mut().next() {
+                    window.select_element(LT::NodeId::from(id));
+                    window.request_redraw();
+                }
+            }
+            CustomEvent::SendNodes(sender) => {
+                for window in self.windows.values_mut() {
+                    window.send_nodes(sender.clone());
+                }
+            }
+
+            CustomEvent::Unselect => {
+                if let Some(window) = self.windows.values_mut().next() {
+                    window.unselect_element();
+                    window.request_redraw();
+                }
+            }
         }
     }
 
@@ -122,6 +141,7 @@ impl<'a, D: SceneDrawer<B, L, LT>, B: RenderBackend, L: Layouter, LT: LayoutTree
             backend,
             layouter,
             proxy: None,
+            event_loop: None,
             open_windows: Vec::new(),
             debug,
         }
@@ -145,20 +165,42 @@ impl<'a, D: SceneDrawer<B, L, LT>, B: RenderBackend, L: Layouter, LT: LayoutTree
         }
     }
 
-    pub fn start(&mut self) -> Result<()> {
+    pub fn initialize(&mut self) -> Result<()> {
         let event_loop = EventLoop::with_user_event().build()?;
 
-        let proxy = event_loop.create_proxy();
+        self.proxy = Some(event_loop.create_proxy());
+        self.event_loop = Some(event_loop);
+
+        Ok(())
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        if self.event_loop.is_none() {
+            self.initialize()?;
+        }
+
+        let event_loop = self
+            .event_loop
+            .take()
+            .ok_or(anyhow!("No event loop; unreachable!"))?;
+
+        let proxy = self.proxy()?;
 
         proxy
             .send_event(CustomEvent::OpenInitial)
             .map_err(|e| anyhow!(e.to_string()))?;
 
-        self.proxy = Some(proxy);
-
         event_loop.run_app(self)?;
 
         Ok(())
+    }
+
+    pub fn proxy(&mut self) -> Result<EventLoopProxy<CustomEvent>> {
+        if self.proxy.is_none() {
+            self.initialize()?;
+        }
+
+        self.proxy.clone().ok_or(anyhow!("No proxy; unreachable!"))
     }
 
     pub fn close_window(&mut self, id: WindowId) {
@@ -169,8 +211,11 @@ impl<'a, D: SceneDrawer<B, L, LT>, B: RenderBackend, L: Layouter, LT: LayoutTree
 }
 
 #[derive(Debug)]
-enum CustomEvent {
+pub enum CustomEvent {
     OpenWindow(Url),
     CloseWindow(WindowId),
     OpenInitial,
+    Select(u64),
+    SendNodes(mpsc::Sender<NodeDesc>),
+    Unselect,
 }

--- a/crates/gosub_useragent/src/tabs.rs
+++ b/crates/gosub_useragent/src/tabs.rs
@@ -1,8 +1,9 @@
 use slotmap::{DefaultKey, SlotMap};
+use std::sync::mpsc::Sender;
 use url::Url;
 
 use gosub_render_backend::layout::{LayoutTree, Layouter};
-use gosub_render_backend::RenderBackend;
+use gosub_render_backend::{NodeDesc, RenderBackend};
 use gosub_renderer::draw::SceneDrawer;
 use gosub_shared::types::Result;
 
@@ -44,6 +45,24 @@ impl<D: SceneDrawer<B, L, LT>, L: Layouter, LT: LayoutTree<L>, B: RenderBackend>
         let tab = Tab::from_url(url, layouter, debug)?;
 
         Ok(Self::new(tab))
+    }
+
+    pub fn select_element(&mut self, id: LT::NodeId) {
+        if let Some(tab) = self.get_current_tab() {
+            tab.data.select_element(id);
+        }
+    }
+
+    pub fn send_nodes(&mut self, sender: Sender<NodeDesc>) {
+        if let Some(tab) = self.get_current_tab() {
+            tab.data.send_nodes(sender);
+        }
+    }
+
+    pub fn unselect_element(&mut self) {
+        if let Some(tab) = self.get_current_tab() {
+            tab.data.unselect_element();
+        }
     }
 }
 

--- a/crates/gosub_useragent/src/window.rs
+++ b/crates/gosub_useragent/src/window.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
-
 use anyhow::anyhow;
 use log::warn;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
 use url::Url;
 use winit::dpi::LogicalSize;
 use winit::event_loop::ActiveEventLoop;
@@ -9,7 +9,7 @@ use winit::window::{Window as WinitWindow, WindowId};
 
 use gosub_render_backend::geo::SizeU32;
 use gosub_render_backend::layout::{LayoutTree, Layouter};
-use gosub_render_backend::RenderBackend;
+use gosub_render_backend::{NodeDesc, RenderBackend};
 use gosub_renderer::draw::SceneDrawer;
 use gosub_shared::types::Result;
 
@@ -92,6 +92,18 @@ impl<'a, D: SceneDrawer<B, L, LT>, B: RenderBackend, L: Layouter, LT: LayoutTree
             WindowState::Active { .. } => "Active",
             WindowState::Suspended => "Suspended",
         }
+    }
+
+    pub fn select_element(&mut self, id: LT::NodeId) {
+        self.tabs.select_element(id);
+    }
+
+    pub fn send_nodes(&mut self, sender: Sender<NodeDesc>) {
+        self.tabs.send_nodes(sender);
+    }
+
+    pub fn unselect_element(&mut self) {
+        self.tabs.unselect_element();
     }
 }
 


### PR DESCRIPTION
This PR adds a "cmdline" interface, to see which nodes there are and how the tree looks. You can then let it select one of the nodes via the node id.

It has the following commands:
- `list` prints the current tree with their IDs
- `select <id>` selects the node with the specified ID and blocks the selection of other nodes via the mouse.
- `unselect` removes the selection, allowing the selection with the mouse again.

I'm not particularity proud of this work, but it gets the job done...

Note: This PR requires at least #536 to be merged and it also contains work from #543 , that's also why this is only a draft PR (and is so large)