### PR TITLE
Support Inline elements

### DIFF
--- a/crates/gosub_html5/src/parser/document.rs
+++ b/crates/gosub_html5/src/parser/document.rs
@@ -287,6 +287,10 @@ impl Document {
         DocumentHandle(Rc::new(RefCell::new(Self::new(location))))
     }
 
+    pub fn peek_next_id(&self) -> NodeId {
+        self.arena.peek_next_id()
+    }
+
     /// Fast clone of a lightweight reference-counted handle for the document.  This is a shallow
     /// clone, and different handles will see the same underlying document.
     pub fn clone(handle: &DocumentHandle) -> DocumentHandle {

--- a/crates/gosub_render_backend/src/layout.rs
+++ b/crates/gosub_render_backend/src/layout.rs
@@ -9,9 +9,9 @@ pub trait LayoutTree<L: Layouter>: Sized {
     fn children(&self, id: Self::NodeId) -> Option<Vec<Self::NodeId>>;
     fn contains(&self, id: &Self::NodeId) -> bool;
     fn child_count(&self, id: Self::NodeId) -> usize;
+    fn parent_id(&self, id: Self::NodeId) -> Option<Self::NodeId>;
     fn get_cache(&self, id: Self::NodeId) -> Option<&L::Cache>;
     fn get_layout(&self, id: Self::NodeId) -> Option<&L::Layout>;
-
     fn get_cache_mut(&mut self, id: Self::NodeId) -> Option<&mut L::Cache>;
     fn get_layout_mut(&mut self, id: Self::NodeId) -> Option<&mut L::Layout>;
     fn set_cache(&mut self, id: Self::NodeId, cache: L::Cache);
@@ -27,6 +27,9 @@ pub trait LayoutTree<L: Layouter>: Sized {
 pub trait Layouter: Sized + Clone {
     type Cache: Default;
     type Layout: Layout;
+
+    const COLLAPSE_INLINE: bool;
+
     fn layout<LT: LayoutTree<Self>>(
         &self,
         tree: &mut LT,
@@ -108,6 +111,10 @@ pub trait Node {
 
     fn get_property(&mut self, name: &str) -> Option<&mut Self::Property>; //TODO: this needs to be more generic...
     fn text_size(&mut self) -> Option<Size>;
+
+    /// This can only return true if the `Layout::COLLAPSE_INLINE` is set true for the layouter
+    ///
+    fn is_anon_inline_parent(&self) -> bool;
 }
 
 pub trait CssProperty {

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -84,7 +84,7 @@ impl<B: RenderBackend, L: Layouter> SceneDrawer<B, L, RenderTree<B, L>> for Tree
             rect: bg,
             transform: None,
             radius: None,
-            brush: Brush::color(Color::MAGENTA),
+            brush: Brush::color(Color::BLACK),
             brush_transform: None,
             border: None,
         };

--- a/crates/gosub_taffy/src/compute.rs
+++ b/crates/gosub_taffy/src/compute.rs
@@ -1,0 +1,1 @@
+pub mod inline;

--- a/crates/gosub_taffy/src/compute/inline.rs
+++ b/crates/gosub_taffy/src/compute/inline.rs
@@ -1,0 +1,94 @@
+use taffy::{
+    AvailableSpace, CollapsibleMarginSet, Layout, LayoutInput, LayoutOutput, LayoutPartialTree,
+    NodeId, Point, ResolveOrZero, RunMode, Size,
+};
+
+use gosub_render_backend::layout::LayoutTree;
+
+use crate::{LayoutDocument, TaffyLayouter};
+
+pub fn compute_inline_layout<LT: LayoutTree<TaffyLayouter>>(
+    tree: &mut LayoutDocument<LT>,
+    nod_id: LT::NodeId,
+    mut layout_input: LayoutInput,
+) -> LayoutOutput {
+    layout_input.known_dimensions = Size::NONE;
+    layout_input.run_mode = RunMode::PerformLayout; //TODO: We should respect the run mode
+
+    let Some(children) = tree.0.children(nod_id) else {
+        return LayoutOutput::HIDDEN;
+    };
+
+    let mut outputs = Vec::with_capacity(children.len());
+
+    let mut height = 0.0f32;
+    for child in &children {
+        let node_id = NodeId::from((*child).into());
+
+        let out = tree.compute_child_layout(node_id, layout_input);
+
+        let style = tree.get_style(node_id);
+
+        let margin = style.margin.resolve_or_zero(layout_input.parent_size);
+
+        let child_height = out.size.height + margin.top + margin.bottom;
+
+        height = height.max(child_height);
+
+        outputs.push(out);
+    }
+
+    let mut width = 0.0f32;
+    for (child, out) in children.into_iter().zip(outputs.into_iter()) {
+        let node_id = NodeId::from(child.into());
+
+        let style = tree.get_style(node_id);
+
+        let location = Point {
+            x: width,
+            y: height - out.size.height,
+        };
+
+        let border = style.border.resolve_or_zero(layout_input.parent_size);
+        let padding = style.padding.resolve_or_zero(layout_input.parent_size);
+
+        width += out.size.width + border.left + border.right + padding.left + padding.right;
+
+        tree.set_unrounded_layout(
+            node_id,
+            &Layout {
+                size: out.size,
+                content_size: out.content_size,
+                order: 0,
+                location,
+                border,
+                padding,
+                scrollbar_size: Size::ZERO, //TODO
+            },
+        );
+    }
+
+    let content_size = Size { width, height };
+
+    let mut size = content_size;
+
+    if let AvailableSpace::Definite(width) = layout_input.available_space.width {
+        size.width = size.width.min(width);
+    }
+
+    if let AvailableSpace::Definite(height) = layout_input.available_space.height {
+        size.height = size.height.min(height);
+    }
+
+    dbg!(size);
+    dbg!(content_size);
+
+    LayoutOutput {
+        size,
+        content_size,
+        first_baselines: Point::NONE,
+        top_margin: CollapsibleMarginSet::ZERO,
+        bottom_margin: CollapsibleMarginSet::ZERO,
+        margins_can_collapse_through: false,
+    }
+}

--- a/crates/gosub_taffy/src/style.rs
+++ b/crates/gosub_taffy/src/style.rs
@@ -1,5 +1,6 @@
 use taffy::Style;
 
+use crate::Display;
 use gosub_render_backend::layout::Node;
 
 mod parse;
@@ -7,9 +8,9 @@ mod parse_properties;
 
 const SCROLLBAR_WIDTH: f32 = 16.0;
 
-pub fn get_style_from_node(node: &mut impl Node) -> Style {
+pub fn get_style_from_node(node: &mut impl Node) -> (Style, Display) {
     //TODO: theoretically we should limit this to the taffy layouter, since it doesn't make any sense otherweise
-    let display = parse_properties::parse_display(node);
+    let (display, disp) = parse_properties::parse_display(node);
     let overflow = parse_properties::parse_overflow(node);
     let position = parse_properties::parse_position(node);
     let inset = parse_properties::parse_inset(node);
@@ -40,37 +41,40 @@ pub fn get_style_from_node(node: &mut impl Node) -> Style {
     let grid_row = parse_properties::parse_grid_row(node);
     let grid_column = parse_properties::parse_grid_column(node);
 
-    Style {
-        display,
-        overflow,
-        scrollbar_width: SCROLLBAR_WIDTH,
-        position,
-        inset,
-        size,
-        min_size,
-        max_size,
-        aspect_ratio,
-        margin,
-        padding,
-        border,
-        align_items,
-        align_self,
-        justify_items,
-        justify_self,
-        align_content,
-        justify_content,
-        gap,
-        flex_direction,
-        flex_wrap,
-        flex_basis,
-        flex_grow,
-        flex_shrink,
-        grid_template_rows,
-        grid_template_columns,
-        grid_auto_rows,
-        grid_auto_columns,
-        grid_auto_flow,
-        grid_row,
-        grid_column,
-    }
+    (
+        Style {
+            display,
+            overflow,
+            scrollbar_width: SCROLLBAR_WIDTH,
+            position,
+            inset,
+            size,
+            min_size,
+            max_size,
+            aspect_ratio,
+            margin,
+            padding,
+            border,
+            align_items,
+            align_self,
+            justify_items,
+            justify_self,
+            align_content,
+            justify_content,
+            gap,
+            flex_direction,
+            flex_wrap,
+            flex_basis,
+            flex_grow,
+            flex_shrink,
+            grid_template_rows,
+            grid_template_columns,
+            grid_auto_rows,
+            grid_auto_columns,
+            grid_auto_flow,
+            grid_row,
+            grid_column,
+        },
+        disp,
+    )
 }

--- a/crates/gosub_taffy/src/style/parse_properties.rs
+++ b/crates/gosub_taffy/src/style/parse_properties.rs
@@ -9,23 +9,23 @@ use crate::style::parse::{
     parse_len, parse_len_auto, parse_text_dim, parse_tracking_sizing_function,
 };
 
-pub fn parse_display(node: &mut impl Node) -> Display {
+pub fn parse_display(node: &mut impl Node) -> (Display, crate::Display) {
     let Some(display) = node.get_property("display") else {
-        return Display::Block;
+        return (Display::Block, crate::Display::Taffy);
     };
 
     display.compute_value();
 
     let Some(value) = display.as_string() else {
-        return Display::Block;
+        return (Display::Block, crate::Display::Taffy);
     };
 
     match value {
-        "none" => Display::None,
-        "block" => Display::Block,
-        "flex" => Display::Flex,
-        "grid" => Display::Grid,
-        _ => Display::Block,
+        "none" => (Display::None, crate::Display::Taffy),
+        "block" => (Display::Block, crate::Display::Taffy),
+        "flex" => (Display::Flex, crate::Display::Taffy),
+        "grid" => (Display::Grid, crate::Display::Taffy),
+        _ => (Display::Block, crate::Display::Taffy),
     }
 }
 

--- a/resources/useragent.css
+++ b/resources/useragent.css
@@ -45,6 +45,10 @@ p {
 div {
     display: block
 }
+
+span {
+    display: inline
+}
 article, aside, footer, header, hgroup, main, nav, search, section {
     display: block
 }


### PR DESCRIPTION
This PR tries to more correctly support inline elements. Currently inline elements are just shown below each other (behave like block elements). This PR at least puts them on the same line, it still isn't right most of the time, for example it would just overflow and not try to position it's elements on the next line. Text also doesn't get spaces between text in `<span>` and a `<p>` tags or text that isn't wrapped in any additional tag.

![image](https://github.com/user-attachments/assets/639ae636-ad43-4106-a2a0-92c52d0922b1)


Note: This PR contains work from #536 and so requires it to be merged before this PR, then this PR will also be way smaller.